### PR TITLE
refactor error handling/reporting completely

### DIFF
--- a/fsm/correlator_test.go
+++ b/fsm/correlator_test.go
@@ -118,7 +118,7 @@ func TestTrackPendingActivities(t *testing.T) {
 	}
 	first := testDecisionTask(0, events)
 
-	_, decisions, _ := fsm.Tick(first)
+	_, decisions, _, _ := fsm.Tick(first)
 	recordMarker := FindDecision(decisions, stateMarkerPredicate)
 	if recordMarker == nil {
 		t.Fatal("No Record State Marker")
@@ -159,7 +159,7 @@ func TestTrackPendingActivities(t *testing.T) {
 	}
 	second := testDecisionTask(3, secondEvents)
 
-	_, secondDecisions, _ := fsm.Tick(second)
+	_, secondDecisions, _, _ := fsm.Tick(second)
 	recordMarker = FindDecision(secondDecisions, stateMarkerPredicate)
 	if recordMarker == nil {
 		t.Fatal("No Record State Marker")
@@ -199,7 +199,7 @@ func TestTrackPendingActivities(t *testing.T) {
 		t.Fatal("current state is not 'working'", thirdEvents)
 	}
 	third := testDecisionTask(7, thirdEvents)
-	_, thirdDecisions, _ := fsm.Tick(third)
+	_, thirdDecisions, _, _ := fsm.Tick(third)
 	recordMarker = FindDecision(thirdDecisions, stateMarkerPredicate)
 	if recordMarker == nil {
 		t.Fatal("No Record State Marker")
@@ -228,7 +228,7 @@ func TestTrackPendingActivities(t *testing.T) {
 		t.Fatal("current state is not 'done'", fourthEvents)
 	}
 	fourth := testDecisionTask(11, fourthEvents)
-	_, fourthDecisions, _ := fsm.Tick(fourth)
+	_, fourthDecisions, _, _ := fsm.Tick(fourth)
 	recordMarker = FindDecision(fourthDecisions, stateMarkerPredicate)
 	if recordMarker == nil {
 		t.Fatal("No Record State Marker")

--- a/fsm/fsm_test.go
+++ b/fsm/fsm_test.go
@@ -85,7 +85,7 @@ func TestFSM(t *testing.T) {
 
 	first := testDecisionTask(0, events)
 
-	_, decisions, _ := fsm.Tick(first)
+	_, decisions, _, _ := fsm.Tick(first)
 
 	if !Find(decisions, stateMarkerPredicate) {
 		t.Fatal("No Record State Marker")
@@ -108,7 +108,7 @@ func TestFSM(t *testing.T) {
 
 	second := testDecisionTask(3, secondEvents)
 
-	_, secondDecisions, _ := fsm.Tick(second)
+	_, secondDecisions, _, _ := fsm.Tick(second)
 
 	if !Find(secondDecisions, stateMarkerPredicate) {
 		t.Fatal("No Record State Marker")
@@ -458,7 +458,7 @@ func TestContinuedWorkflows(t *testing.T) {
 	}})
 
 	log.Printf("%+v", resp)
-	_, decisions, updatedState := fsm.Tick(resp)
+	_, decisions, updatedState, _ := fsm.Tick(resp)
 
 	log.Println(updatedState)
 


### PR DESCRIPTION
/cc @fabiokung @dgouldin

With a bit of inspiration from http://www.boost.org/doc/libs/1_39_0/libs/statechart/doc/rationale.html#ErrorHandling

Basically there are 2 types of errors. Errors in the FSM which are generally unrecoverable without a config or code change and Decision errors/panics which may be. 

If a DecisionErrorHandler can successfully recover, we continue processing the decisionTask, if not, we abandon any further processing.

```go
//DecisionErrorHandler is the error handling contract for panics that occur in Deciders.
//If your DecisionErrorHandler does not return a non nil Outcome, any further attempt to process the decisionTask is abandoned and the task will time out.
type DecisionErrorHandler func(ctx *FSMContext, event swf.HistoryEvent, stateBeforeEvent interface{}, stateAfterError interface{}, err error) (*Outcome, error)

//FSMErrorReporter is the error handling contract for errors in the FSM machinery itself.
//These are generally a misconfiguration of your FSM or mismatch between struct and serialized form and cant be resolved without config/code changes
//the paramaters to each method provide all availabe info at the time of the error so you can diagnose issues.
//Note that this is a diagnostic interface that basically leaks implementation details, and as such may change from release to release.
type FSMErrorReporter interface {
	ErrorFindingStateData(decisionTask *swf.DecisionTask, err error)
	ErrorFindingCorrelator(decisionTask *swf.DecisionTask, err error)
	ErrorMissingFSMState(decisionTask *swf.DecisionTask, outcome Outcome)
	ErrorDeserializingStateData(decisionTask *swf.DecisionTask, serializedStateData string, err error)
	ErrorSerializingStateData(decisionTask *swf.DecisionTask, outcome Outcome, eventCorrelator EventCorrelator, err error)
}
```