### PR TITLE
update error handling to allow error recovery as well

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,3 +41,4 @@ dependencies:
 	go get github.com/awslabs/aws-sdk-go/gen/kinesis
 	go get github.com/awslabs/aws-sdk-go/gen/swf
 	go get code.google.com/p/go-uuid/uuid
+	go get github.com/juju/errors

--- a/fsm/fsm_models.go
+++ b/fsm/fsm_models.go
@@ -16,8 +16,7 @@ import (
 const (
 	StateMarker       = "FSM.State"
 	CorrelatorMarker  = "FSM.Correlator"
-	ErrorSignal       = "FSM.Error"
-	SystemErrorSignal = "FSM.SystemError"
+	ErrorMarker       = "FSM.Error"
 	RepiarStateSignal = "FSM.RepairState"
 	ContinueTimer     = "FSM.ContinueWorkflow"
 	ContinueSignal    = "FSM.ContinueWorkflow"
@@ -77,22 +76,6 @@ type ReplicationData struct {
 	StateVersion uint64 `json:"stateVersion"`
 	StateName    string `json:"stateName"`
 	StateData    string `json:"stateData"`
-}
-
-// SerializedDecisionError is a wrapper struct that allows serializing the context in which an error in a Decider occurred
-// into a WorkflowSignaledEvent in the workflow history.
-type SerializedDecisionError struct {
-	ErrorEvent swf.HistoryEvent `json:"errorEvent"`
-	Error      interface{}      `json:"error"`
-}
-
-// SerializedSystemError is a wrapper struct that allows serializing the context in which an error internal to FSM processing has occurred
-// into a WorkflowSignaledEvent in the workflow history. These errors are generally in finding the current state and data for a workflow, or
-// in serializing and deserializing said state.
-type SerializedSystemError struct {
-	ErrorType           string      `json:"errorType"`
-	Error               interface{} `json:"error"`
-	UnprocessedEventIDs []int64     `json:"unprocessedEventIds"`
 }
 
 // StateSerializer defines the interface for serializing state to and deserializing state from the workflow history.
@@ -334,4 +317,11 @@ type SerializedState struct {
 	StateVersion uint64 `json:"stateVersion"`
 	StateName    string `json:"stateName"`
 	StateData    string `json:"stateData"`
+}
+
+//ErrorState is used as the input to a marker that signifies that the workflow is in an error state.
+type SerializedErrorState struct {
+	EarliestUnprocessedEventID int64
+	LatestUnprocessedEventID   int64
+	ErrorEvent                 swf.HistoryEvent
 }


### PR DESCRIPTION
Enhanced error handling / recovery behavior.

Instead of simply abandoning processing of a decisionTask that has an nil Outcome from the DecisionErrorHandler or an FSMError, we instead just respond to the decisionTask with 3 state markers (which do not initiate any further decisions on their own).

* the standard state marker -> `SerializedState`
* the standard correlator marker -> `EventCorrelator`
* an ErrorState marker ->  `SerializedErrorState` (the HistoryEvent that caused the error, the range of `EventID`s that are unprocessed)

On any subsequent DecisionTask, the FSM will notice an error marker, which places the workflow in an error mode. 

It will have already deserialized the latest "good" copy of the `SerializedState` and `EventCorrelator` from the previous markers.

FSM then attempts to call the `DecisionErrorHandler` for the state with `SerializedErrorState.ErrorEvent` (the event that caused the errorState), and latest good data.

If the errorHandler *does no*t return non-nil outcome, we just respond with the 3 markers, again, where the `SerializedErrorState` is updated to contain the now broader range of unprocessed eventIds.

If the errorHandler *does* return non-nil outcome this time around. (Lets say a subsequent code deploy was made that understands recovering from this particular kind of error state) then we use that outcome to process the range of unprocessed events (for now we assume the are all present in the DecisionTask, and we filter out all error markers)

Once we have successfully processed the previously unprocessed range of events in the SerializedError state, we can go back to processing the actual `DecisionTask` that returned us the latest errorState marker.

/cc @fabiokung @dgouldin  this is a good bit more complex, so we can try to go without this for a while and if we find we need this, bring it in.




