### PR TITLE
add DecisionInterceptor which gives the ability to intercept decision tasks at key points in the decision lifecycle

### DIFF
--- a/fsm/interceptors.go
+++ b/fsm/interceptors.go
@@ -1,0 +1,40 @@
+package fsm
+
+import (
+	"github.com/awslabs/aws-sdk-go/gen/swf"
+)
+
+//DecisionInterceptor allows manipulation of the decision task and the outcome at key points in the task lifecycle.
+type DecisionInterceptor interface {
+	BeforeTask(decision *swf.DecisionTask)
+	BeforeDecision(decision *swf.DecisionTask, ctx *FSMContext, outcome Outcome)
+	AfterDecision(decision *swf.DecisionTask, ctx *FSMContext, outcome Outcome)
+}
+
+//FuncInterceptor is a DecisionInterceptor that you can set handler funcs on. if any are unset, they are no-ops.
+type FuncInterceptor struct {
+	BeforeTaskFn     func(decision *swf.DecisionTask)
+	BeforeDecisionFn func(decision *swf.DecisionTask, ctx *FSMContext, outcome Outcome)
+	AfterDecisionFn  func(decision *swf.DecisionTask, ctx *FSMContext, outcome Outcome)
+}
+
+//BeforeTask runs the BeforeTaskFn if not nil
+func (i *FuncInterceptor) BeforeTask(decision *swf.DecisionTask) {
+	if i.BeforeTaskFn != nil {
+		i.BeforeTaskFn(decision)
+	}
+}
+
+//BeforeDecision runs the BeforeDecisionFn if not nil
+func (i *FuncInterceptor) BeforeDecision(decision *swf.DecisionTask, ctx *FSMContext, outcome Outcome) {
+	if i.BeforeDecisionFn != nil {
+		i.BeforeDecisionFn(decision, ctx, outcome)
+	}
+}
+
+//AfterDecision runs the AfterDecisionFn if not nil
+func (i *FuncInterceptor) AfterDecision(decision *swf.DecisionTask, ctx *FSMContext, outcome Outcome) {
+	if i.AfterDecisionFn != nil {
+		i.AfterDecisionFn(decision, ctx, outcome)
+	}
+}

--- a/fsm/interceptors_test.go
+++ b/fsm/interceptors_test.go
@@ -1,0 +1,68 @@
+package fsm
+
+import (
+	"github.com/awslabs/aws-sdk-go/gen/swf"
+	. "github.com/sclasen/swfsm/sugar"
+	"testing"
+)
+
+func TestInterceptors(t *testing.T) {
+	calledAfter := false
+	calledBefore := false
+	calledBeforeCtx := false
+
+	interceptor := &FuncInterceptor{
+		BeforeTaskFn: func(decision *swf.DecisionTask) {
+			calledBefore = true
+		},
+		BeforeDecisionFn: func(decision *swf.DecisionTask, ctx *FSMContext, outcome Outcome) {
+			calledBeforeCtx = true
+		},
+		AfterDecisionFn: func(decision *swf.DecisionTask, ctx *FSMContext, outcome Outcome) {
+			calledAfter = true
+		},
+	}
+
+	fsm := &FSM{
+		Name:                "test-fsm",
+		DataType:            TestData{},
+		DecisionInterceptor: interceptor,
+		Serializer:          JSONStateSerializer{},
+		systemSerializer:    JSONStateSerializer{},
+	}
+
+	fsm.AddInitialState(&FSMState{Name: "initial", Decider: func(ctx *FSMContext, e swf.HistoryEvent, d interface{}) Outcome {
+		return Outcome{State: "initial", Data: d, Decisions: []swf.Decision{}}
+	}})
+
+	decisionTask := new(swf.DecisionTask)
+	decisionTask.WorkflowExecution = new(swf.WorkflowExecution)
+	decisionTask.WorkflowType = &swf.WorkflowType{Name: S("test"), Version: S("1")}
+	decisionTask.WorkflowExecution.RunID = S("run")
+	decisionTask.WorkflowExecution.WorkflowID = S("wf")
+	decisionTask.PreviousStartedEventID = I(5)
+	decisionTask.StartedEventID = I(15)
+	decisionTask.Events = []swf.HistoryEvent{
+		{
+			EventID:   I(10),
+			EventType: S("WorkflowExecutionStarted"),
+			WorkflowExecutionStartedEventAttributes: &swf.WorkflowExecutionStartedEventAttributes{
+				Input: S(fsm.Serialize(new(TestData))),
+			},
+		},
+	}
+
+	fsm.Tick(decisionTask)
+
+	if calledBefore == false {
+		t.Fatalf("before not called")
+	}
+
+	if calledBeforeCtx == false {
+		t.Fatalf("before context not called")
+	}
+
+	if calledBefore == false {
+		t.Fatalf("after not called")
+	}
+}

--- a/fsm/interceptors_test.go
+++ b/fsm/interceptors_test.go
@@ -1,9 +1,10 @@
 package fsm
 
 import (
+	"testing"
+
 	"github.com/awslabs/aws-sdk-go/gen/swf"
 	. "github.com/sclasen/swfsm/sugar"
-	"testing"
 )
 
 func TestInterceptors(t *testing.T) {


### PR DESCRIPTION
Potential usages. 

* DecisionInterceptor.BeforeTask: load more history/filter history before state is deserialized
* DecisionInterceptor.BeforeDecision: fix or migrate stateData or state.
* DecisionInterceptor.AfterDecision: Make additional Decisons based on the full Outcome, filter Decisions from Outcome, e.g. make sure only one Complete or Continue Workflow decision is in the Outcome.
