### PR TITLE
Testing fixes

### DIFF
--- a/poller/poller.go
+++ b/poller/poller.go
@@ -10,7 +10,7 @@ import (
 	. "github.com/sclasen/swfsm/sugar"
 )
 
-// SWFOps is the subset of the swf.SWF api used bu pollers
+// SWFOps is the subset of the swf.SWF api used by pollers
 type DecisionOps interface {
 	PollForDecisionTask(req *swf.PollForDecisionTaskInput) (resp *swf.DecisionTask, err error)
 }

--- a/testing/listener.go
+++ b/testing/listener.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 
 	"github.com/awslabs/aws-sdk-go/gen/swf"
-	"github.com/sclasen/swfsm/Godeps/_workspace/src/code.google.com/p/go-uuid/uuid"
+	"code.google.com/p/go-uuid/uuid"
 	"github.com/sclasen/swfsm/activity"
 	"github.com/sclasen/swfsm/fsm"
 )

--- a/testing/listener.go
+++ b/testing/listener.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/awslabs/aws-sdk-go/gen/swf"
 	"github.com/sclasen/swfsm/Godeps/_workspace/src/code.google.com/p/go-uuid/uuid"
-	"github.com/sclasen/swfsm/fsm"
 	"github.com/sclasen/swfsm/activity"
+	"github.com/sclasen/swfsm/fsm"
 )
 
 type TestAdapter interface {
@@ -18,11 +18,12 @@ type TestAdapter interface {
 	FailNow()
 }
 
-type TestConfig struct{
-	Testing TestAdapter
-	FSMs []*fsm.FSM
-	Workers []*activity.ActivityWorker
-	StubbedWorkflows []string
+type TestConfig struct {
+	Testing               TestAdapter
+	FSM                   *fsm.FSM
+	StubFSM               *fsm.FSM
+	Workers               []*activity.ActivityWorker
+	StubbedWorkflows      []string
 	ShortStubbedWorkflows []string
 }
 
@@ -38,10 +39,12 @@ func NewTestListener(t TestConfig) *TestListener {
 		TestID:           uuid.New(),
 	}
 
-	for _, f := range t.FSMs {
-		f.ReplicationHandler = TestReplicator(tl.decisionOutcomes)
-		f.DecisionInterceptor = TestInterceptor(tl.TestID, t.StubbedWorkflows, t.ShortStubbedWorkflows)
-		f.TaskList = tl.TestID
+	t.FSM.ReplicationHandler = TestReplicator(tl.decisionOutcomes)
+	t.FSM.DecisionInterceptor = TestInterceptor(tl.TestID, t.StubbedWorkflows, t.ShortStubbedWorkflows)
+	t.FSM.TaskList = tl.TestID
+
+	if t.StubFSM != nil {
+		t.StubFSM.ReplicationHandler = TestReplicator(tl.decisionOutcomes)
 	}
 
 	for _, w := range t.Workers {

--- a/testing/listener.go
+++ b/testing/listener.go
@@ -6,8 +6,8 @@ import (
 
 	"fmt"
 
-	"github.com/awslabs/aws-sdk-go/gen/swf"
 	"code.google.com/p/go-uuid/uuid"
+	"github.com/awslabs/aws-sdk-go/gen/swf"
 	"github.com/sclasen/swfsm/activity"
 	"github.com/sclasen/swfsm/fsm"
 )

--- a/testing/listener.go
+++ b/testing/listener.go
@@ -7,6 +7,9 @@ import (
 	"fmt"
 
 	"github.com/awslabs/aws-sdk-go/gen/swf"
+	"github.com/sclasen/swfsm/Godeps/_workspace/src/code.google.com/p/go-uuid/uuid"
+	"github.com/sclasen/swfsm/fsm"
+	"github.com/sclasen/swfsm/activity"
 )
 
 type TestAdapter interface {
@@ -15,15 +18,37 @@ type TestAdapter interface {
 	FailNow()
 }
 
-func NewTestListener(t TestAdapter, decisionOutcomes chan DecisionOutcome) *TestListener {
+type TestConfig struct{
+	Testing TestAdapter
+	FSMs []*fsm.FSM
+	Workers []*activity.ActivityWorker
+	StubbedWorkflows []string
+	ShortStubbedWorkflows []string
+}
+
+func NewTestListener(t TestConfig) *TestListener {
+
 	tl := &TestListener{
-		decisionOutcomes: decisionOutcomes,
+		decisionOutcomes: make(chan DecisionOutcome, 1000),
 		historyInterest:  make(map[string]chan swf.HistoryEvent, 1000),
 		decisionInterest: make(map[string]chan swf.Decision, 1000),
 		stateInterest:    make(map[string]chan string, 1000),
 		DefaultWait:      10 * time.Second,
-		testAdapter:      t,
+		testAdapter:      t.Testing,
+		TestID:           uuid.New(),
 	}
+
+	for _, f := range t.FSMs {
+		f.ReplicationHandler = TestReplicator(tl.decisionOutcomes)
+		f.DecisionInterceptor = TestInterceptor(tl.TestID, t.StubbedWorkflows, t.ShortStubbedWorkflows)
+		f.TaskList = tl.TestID
+	}
+
+	for _, w := range t.Workers {
+		w.TaskList = w.TaskList + tl.TestID
+		w.AllowPanics = true
+	}
+
 	tl.Start()
 	return tl
 }
@@ -38,6 +63,7 @@ type TestListener struct {
 	stateLock        sync.Mutex
 	DefaultWait      time.Duration
 	testAdapter      TestAdapter
+	TestID           string
 }
 
 func (tl *TestListener) RegisterHistoryInterest(workflowID string) chan swf.HistoryEvent {

--- a/testing/stubs.go
+++ b/testing/stubs.go
@@ -99,11 +99,7 @@ func TestInterceptor(testID string, stubbedWorkflows, stubbedShortWorkflows []st
 						d.StartChildWorkflowExecutionDecisionAttributes.TaskList = ShortStubTaskList
 					}
 				case swf.DecisionTypeScheduleActivityTask:
-				    log.Printf("%+v", d.ScheduleActivityTaskDecisionAttributes)
-				    log.Printf("%+v", d.ScheduleActivityTaskDecisionAttributes.TaskList.Name)
-					d.ScheduleActivityTaskDecisionAttributes.TaskList.Name = S(*d.ScheduleActivityTaskDecisionAttributes.TaskList.Name + testID)
-				    log.Printf("%+v", d.ScheduleActivityTaskDecisionAttributes.TaskList.Name)
-
+					d.ScheduleActivityTaskDecisionAttributes.TaskList = &swf.TaskList{Name: S(*d.ScheduleActivityTaskDecisionAttributes.TaskList.Name + testID)}
 				}
 			}
 		},

--- a/testing/stubs.go
+++ b/testing/stubs.go
@@ -71,7 +71,7 @@ func ShortStubState() fsm.Decider {
 }
 
 //intercept any attempts to start a workflow and launch the stub workflow instead.
-func TestInterceptor(activityTaskList string, stubbedWorkflows, stubbedShortWorkflows []string) *fsm.FuncInterceptor {
+func TestInterceptor(testID string, stubbedWorkflows, stubbedShortWorkflows []string) *fsm.FuncInterceptor {
 	stubbed := make(map[string]struct{})
 	stubbedShort := make(map[string]struct{})
 	v := struct{}{}
@@ -99,8 +99,7 @@ func TestInterceptor(activityTaskList string, stubbedWorkflows, stubbedShortWork
 						d.StartChildWorkflowExecutionDecisionAttributes.TaskList = ShortStubTaskList
 					}
 				case swf.DecisionTypeScheduleActivityTask:
-					d.ScheduleActivityTaskDecisionAttributes.StartToCloseTimeout = S("1")
-					d.ScheduleActivityTaskDecisionAttributes.TaskList = &swf.TaskList{Name: S(activityTaskList)}
+					d.ScheduleActivityTaskDecisionAttributes.TaskList.Name = S(*d.ScheduleActivityTaskDecisionAttributes.TaskList.Name + testID)
 				}
 			}
 		},

--- a/testing/stubs.go
+++ b/testing/stubs.go
@@ -98,6 +98,8 @@ func TestInterceptor(stubbedWorkflows, stubbedShortWorkflows []string) *fsm.Func
 						d.StartChildWorkflowExecutionDecisionAttributes.ExecutionStartToCloseTimeout = S("360")
 						d.StartChildWorkflowExecutionDecisionAttributes.TaskList = ShortStubTaskList
 					}
+				case swf.DecisionTypeScheduleActivityTask:
+					d.ScheduleActivityTaskDecisionAttributes.StartToCloseTimeout = S("1")
 				}
 			}
 		},

--- a/testing/stubs.go
+++ b/testing/stubs.go
@@ -28,12 +28,12 @@ type DecisionOutcome struct {
 
 func StubFSM(domain string, client fsm.SWFOps) *fsm.FSM {
 	f := &fsm.FSM{
-		SWF:                client,
-		DataType:           make(map[string]interface{}),
-		Domain:             domain,
-		Name:               StubWorkflow,
-		Serializer:         fsm.JSONStateSerializer{},
-		TaskList:           *StubTaskList.Name,
+		SWF:        client,
+		DataType:   make(map[string]interface{}),
+		Domain:     domain,
+		Name:       StubWorkflow,
+		Serializer: fsm.JSONStateSerializer{},
+		TaskList:   *StubTaskList.Name,
 	}
 
 	f.AddInitialState(&fsm.FSMState{Name: "Initial", Decider: StubState()})
@@ -49,12 +49,12 @@ func StubState() fsm.Decider {
 
 func ShortStubFSM(domain string, client fsm.SWFOps) *fsm.FSM {
 	f := &fsm.FSM{
-		SWF:                client,
-		DataType:           make(map[string]interface{}),
-		Domain:             domain,
-		Name:               ShortStubWorkflow,
-		Serializer:         fsm.JSONStateSerializer{},
-		TaskList:           *StubTaskList.Name,
+		SWF:        client,
+		DataType:   make(map[string]interface{}),
+		Domain:     domain,
+		Name:       ShortStubWorkflow,
+		Serializer: fsm.JSONStateSerializer{},
+		TaskList:   *StubTaskList.Name,
 	}
 
 	f.AddInitialState(&fsm.FSMState{Name: "Initial", Decider: ShortStubState()})

--- a/testing/stubs.go
+++ b/testing/stubs.go
@@ -26,7 +26,7 @@ type DecisionOutcome struct {
 	Decisions    []swf.Decision
 }
 
-func StubFSM(domain string, client fsm.SWFOps, outcomes chan DecisionOutcome) *fsm.FSM {
+func StubFSM(domain string, client fsm.SWFOps) *fsm.FSM {
 	f := &fsm.FSM{
 		SWF:                client,
 		DataType:           make(map[string]interface{}),
@@ -34,7 +34,6 @@ func StubFSM(domain string, client fsm.SWFOps, outcomes chan DecisionOutcome) *f
 		Name:               StubWorkflow,
 		Serializer:         fsm.JSONStateSerializer{},
 		TaskList:           *StubTaskList.Name,
-		ReplicationHandler: TestReplicator(outcomes),
 	}
 
 	f.AddInitialState(&fsm.FSMState{Name: "Initial", Decider: StubState()})
@@ -48,7 +47,7 @@ func StubState() fsm.Decider {
 	}
 }
 
-func ShortStubFSM(domain string, client fsm.SWFOps, outcomes chan DecisionOutcome) *fsm.FSM {
+func ShortStubFSM(domain string, client fsm.SWFOps) *fsm.FSM {
 	f := &fsm.FSM{
 		SWF:                client,
 		DataType:           make(map[string]interface{}),
@@ -56,7 +55,6 @@ func ShortStubFSM(domain string, client fsm.SWFOps, outcomes chan DecisionOutcom
 		Name:               ShortStubWorkflow,
 		Serializer:         fsm.JSONStateSerializer{},
 		TaskList:           *StubTaskList.Name,
-		ReplicationHandler: TestReplicator(outcomes),
 	}
 
 	f.AddInitialState(&fsm.FSMState{Name: "Initial", Decider: ShortStubState()})

--- a/testing/stubs.go
+++ b/testing/stubs.go
@@ -71,7 +71,7 @@ func ShortStubState() fsm.Decider {
 }
 
 //intercept any attempts to start a workflow and launch the stub workflow instead.
-func TestInterceptor(stubbedWorkflows, stubbedShortWorkflows []string) *fsm.FuncInterceptor {
+func TestInterceptor(activityTaskList string, stubbedWorkflows, stubbedShortWorkflows []string) *fsm.FuncInterceptor {
 	stubbed := make(map[string]struct{})
 	stubbedShort := make(map[string]struct{})
 	v := struct{}{}
@@ -100,6 +100,7 @@ func TestInterceptor(stubbedWorkflows, stubbedShortWorkflows []string) *fsm.Func
 					}
 				case swf.DecisionTypeScheduleActivityTask:
 					d.ScheduleActivityTaskDecisionAttributes.StartToCloseTimeout = S("1")
+					d.ScheduleActivityTaskDecisionAttributes.TaskList = &swf.TaskList{Name: S(activityTaskList)}
 				}
 			}
 		},

--- a/testing/stubs.go
+++ b/testing/stubs.go
@@ -99,7 +99,11 @@ func TestInterceptor(testID string, stubbedWorkflows, stubbedShortWorkflows []st
 						d.StartChildWorkflowExecutionDecisionAttributes.TaskList = ShortStubTaskList
 					}
 				case swf.DecisionTypeScheduleActivityTask:
+				    log.Printf("%+v", d.ScheduleActivityTaskDecisionAttributes)
+				    log.Printf("%+v", d.ScheduleActivityTaskDecisionAttributes.TaskList.Name)
 					d.ScheduleActivityTaskDecisionAttributes.TaskList.Name = S(*d.ScheduleActivityTaskDecisionAttributes.TaskList.Name + testID)
+				    log.Printf("%+v", d.ScheduleActivityTaskDecisionAttributes.TaskList.Name)
+
 				}
 			}
 		},


### PR DESCRIPTION
Rework the testing utils to make setup boilerplate less painful

Also insert per-test Decision and Activity TaskLists so tests can be run continuously without falling victim to the phantom task assignment bug.

