### PR TITLE
Entry decisions

### DIFF
--- a/fsm/deciders.go
+++ b/fsm/deciders.go
@@ -192,6 +192,12 @@ func typeCheck(typedFunc interface{}, in []string, out []string) {
 	}
 }
 
+func ToMulti(f DecisionFunc) MultiDecisionFunc {
+	return func(ctx *FSMContext, h swf.HistoryEvent, data interface{}) []swf.Decision {
+		return []swf.Decision{f(ctx, h, data)}
+	}
+}
+
 // OnStarted builds a composed decider that fires on swf.EventTypeWorkflowExecutionStarted.
 func OnStarted(deciders ...Decider) Decider {
 	return func(ctx *FSMContext, h swf.HistoryEvent, data interface{}) Outcome {

--- a/fsm/deciders_test.go
+++ b/fsm/deciders_test.go
@@ -223,7 +223,7 @@ func testContextWithActivity(scheduledEventId int, event *swf.ActivityTaskSchedu
 		correlator := &EventCorrelator{}
 		correlator.Track(s.EventFromPayload(scheduledEventId, event))
 		ctx := deciderTestContext()
-		ctx.eventCorrelator = correlator
+		ctx.EventCorrelator = correlator
 		return ctx
 	}
 }

--- a/fsm/fsm.go
+++ b/fsm/fsm.go
@@ -311,7 +311,7 @@ func (f *FSM) Tick(decisionTask *swf.DecisionTask) (*FSMContext, []swf.Decision,
 		}
 		return nil, nil, nil, errors.Trace(err)
 	}
-	context.eventCorrelator = eventCorrelator
+	context.EventCorrelator = eventCorrelator
 
 	f.clog(context, "action=tick at=find-serialized-state state=%s", serializedState.StateName)
 
@@ -431,7 +431,7 @@ func (f *FSM) Tick(decisionTask *swf.DecisionTask) (*FSMContext, []swf.Decision,
 		outcome.Data = after.Data
 	}
 
-	final, serializedState, err := f.recordStateMarkers(context.stateVersion, outcome, context.eventCorrelator, nil)
+	final, serializedState, err := f.recordStateMarkers(context.stateVersion, outcome, context.EventCorrelator, nil)
 	if err != nil {
 		f.FSMErrorReporter.ErrorSerializingStateData(decisionTask, *outcome, *eventCorrelator, err)
 		if f.allowPanics {

--- a/fsm/fsm_models.go
+++ b/fsm/fsm_models.go
@@ -53,6 +53,8 @@ type FSMState struct {
 	Name string
 	// Decider decides an Outcome given the current state, data, and an event.
 	Decider Decider
+	// Returns the Decisions that the State expects to have made (running activities)
+	EntryDecisions MultiDecisionFunc
 }
 
 //DecisionErrorHandler is the error handling contract for panics that occur in Deciders.

--- a/fsm/fsm_models.go
+++ b/fsm/fsm_models.go
@@ -142,7 +142,7 @@ type FSMContext struct {
 	serialization Serialization
 	swf.WorkflowType
 	swf.WorkflowExecution
-	eventCorrelator *EventCorrelator
+	EventCorrelator *EventCorrelator
 	State           string
 	stateData       interface{}
 	stateVersion    uint64
@@ -158,7 +158,7 @@ func NewFSMContext(
 		serialization:     serialization,
 		WorkflowType:      wfType,
 		WorkflowExecution: wfExec,
-		eventCorrelator:   eventCorrelator,
+		EventCorrelator:   eventCorrelator,
 		State:             state,
 		stateData:         stateData,
 		stateVersion:      stateVersion,
@@ -227,7 +227,7 @@ func (f *FSMContext) ContinueWorkflow(data interface{}, decisions ...swf.Decisio
 // Decide executes a decider making sure that Activity tasks are being tracked.
 func (f *FSMContext) Decide(h swf.HistoryEvent, data interface{}, decider Decider) Outcome {
 	outcome := decider(f, h, data)
-	f.eventCorrelator.Track(h)
+	f.EventCorrelator.Track(h)
 	return outcome
 }
 
@@ -240,24 +240,24 @@ func (f *FSMContext) EventData(h swf.HistoryEvent, data interface{}) {
 // ActivityTasks are automatically tracked after a EventTypeActivityTaskScheduled event.
 // When there is no pending activity related to the event, nil is returned.
 func (f *FSMContext) ActivityInfo(h swf.HistoryEvent) *ActivityInfo {
-	return f.eventCorrelator.ActivityInfo(h)
+	return f.EventCorrelator.ActivityInfo(h)
 }
 
 // ActivitiesInfo will return a map of scheduledID -> ActivityInfo for all in-flight activities in the workflow.
 func (f *FSMContext) ActivitiesInfo() map[string]*ActivityInfo {
-	return f.eventCorrelator.Activities
+	return f.EventCorrelator.Activities
 }
 
 // SignalInfo will find information for ActivityTasks being tracked. It can only be used when handling events related to ActivityTasks.
 // ActivityTasks are automatically tracked after a EventTypeActivityTaskScheduled event.
 // When there is no pending activity related to the event, nil is returned.
 func (f *FSMContext) SignalInfo(h swf.HistoryEvent) *SignalInfo {
-	return f.eventCorrelator.SignalInfo(h)
+	return f.EventCorrelator.SignalInfo(h)
 }
 
 // SignalsInfo will return a map of scheduledId -> ActivityInfo for all in-flight activities in the workflow.
 func (f *FSMContext) SignalsInfo() map[string]*SignalInfo {
-	return f.eventCorrelator.Signals
+	return f.EventCorrelator.Signals
 }
 
 // Serialize will use the current fsm's Serializer to serialize the given struct. It will panic on errors, which is ok in the context of a Decider.


### PR DESCRIPTION
Add optional FSMState.EntryDecisions MultiDecisionFunc

func that fires anytime a state is being entered. this allows simplifying workflows where many states transition to a given state, and would have startActivity boilerplate.

Also, make FSMContext eventCorrelator public and add a util decider func.