### PR TITLE
worker managed backoff on activity failures

### DIFF
--- a/activity/worker.go
+++ b/activity/worker.go
@@ -183,7 +183,6 @@ func (h *ActivityWorker) fail(task *swf.ActivityTask, err error) {
 		})
 		if err == nil {
 			for _, e := range hist.Events {
-				log.Println(PrettyHistoryEvent(e))
 				if *e.EventType == swf.EventTypeMarkerRecorded && *e.MarkerRecordedEventAttributes.MarkerName == fsm.CorrelatorMarker {
 					correlator := new(fsm.EventCorrelator)
 					err := h.Serializer.Deserialize(*e.MarkerRecordedEventAttributes.Details, correlator)
@@ -196,6 +195,7 @@ func (h *ActivityWorker) fail(task *swf.ActivityTask, err error) {
 						log.Printf("workflow-id=%s activity-id=%s activity-id=%s at=retry-backoff attempts=%d sleep=%d ", LS(task.WorkflowExecution.WorkflowID), LS(task.ActivityType.Name), LS(task.ActivityID), attempts, sleep)
 						time.Sleep(time.Duration(sleep) * time.Second)
 					}
+					break
 				}
 			}
 		}

--- a/activity/worker.go
+++ b/activity/worker.go
@@ -6,13 +6,14 @@ import (
 
 	"time"
 
+	"math"
+
 	"github.com/awslabs/aws-sdk-go/aws"
 	"github.com/awslabs/aws-sdk-go/gen/swf"
 	"github.com/juju/errors"
 	"github.com/sclasen/swfsm/fsm"
 	"github.com/sclasen/swfsm/poller"
 	. "github.com/sclasen/swfsm/sugar"
-	"math"
 )
 
 type SWFOps interface {
@@ -211,7 +212,7 @@ func (h *ActivityWorker) fail(task *swf.ActivityTask, err error) {
 
 func (h *ActivityWorker) backoff(attempts int) int {
 	// 0.5, 1, 2, 4, 8...
-	exp := attempts -1
+	exp := attempts - 1
 	if exp > 30 {
 		//int wraps at 31
 		exp = 30


### PR DESCRIPTION
when the `ActivityWorker` is configured with `BackoffOnFailure = true`, then on activity failures, look up the event correlator from workflow history, and read the number of times the current activity has retried, backing off exponentially, up to `MaxBackoffSeconds`.


/cc @fabiokung 