### PR TITLE
rework coordinated handler, was not useful in practice

### DIFF
--- a/activity/coordinated_worker.go
+++ b/activity/coordinated_worker.go
@@ -37,7 +37,12 @@ func (w *ActivityWorker) AddCoordinatedHandler(heartbeatInterval time.Duration, 
 			if err != nil {
 				startErr <- err
 			} else {
-				handlerTickFunc(activityTask, input)
+                err = w.signalStart(activityTask)
+				if err != nil {
+					startErr <- err
+				} else {
+					handlerTickFunc(activityTask, input)
+				}
 			}
 		}()
 	}

--- a/activity/coordinated_worker.go
+++ b/activity/coordinated_worker.go
@@ -15,7 +15,7 @@ const (
 	TaskGone = "Unknown activity"
 )
 
-func (w *ActivityWorker) AddCoordinatedHandler(heartbeatInterval time.Duration, heartbeatErrorThreshold int, handler *CoordinatedActivityHandler) {
+func (w *ActivityWorker) AddCoordinatedHandler(heartbeatInterval time.Duration, handler *CoordinatedActivityHandler) {
 
 	ticks := make(chan CoordinatedActivityHandlerTick)
 	startErr := make(chan error)

--- a/activity/coordinated_worker.go
+++ b/activity/coordinated_worker.go
@@ -54,6 +54,7 @@ func (w *ActivityWorker) AddCoordinatedHandler(heartbeatInterval time.Duration, 
 		for {
 			select {
 			case e := <-startErr:
+				log.Printf("workflow-id=%s activity-id=%s activity-id=%s at=start-error error=%q", LS(activityTask.WorkflowExecution.WorkflowID), LS(activityTask.ActivityType.Name), LS(activityTask.ActivityID), e)
 				w.fail(activityTask, e)
 				return
 			case tick := <-ticks:

--- a/activity/coordinated_worker.go
+++ b/activity/coordinated_worker.go
@@ -11,65 +11,81 @@ import (
 	. "github.com/sclasen/swfsm/sugar"
 )
 
-//NewCoordinatedActivityHandler creates a LongRunningActivityFunc that will build a LongRunningActivityCoordinator and execute your HandleCoordinatedActivity
-//
-// * heartbeats the activity at the given interval
-// * sends any errors heartbeating into the HeartbeatErrors channel, which is buffered by heartbeatErrorThreshold
-// * if the send to HeartbeatErrors blocks because the buffer is full and not being consumed the task will eventually timeout.
-// * if the heartbeat indicates the task was canceled, send on the ToCancelActivity channel and wait on ToAckCancelActivity channel
-// * your CoordinatedActivityHandler is responsible for responding to messages on ToCancelActivity, by stopping, acking the cancel to swf, and sending on ToAckCancel
-// * if your CoordinatedActivityHandler wishes to stop heartbeats, send on ToStopHeartbeating and recieve on ToAckStopHeartbeating.
-// * your CoordinatedActivityHandler is responsible for responding to messages on ToStopActivity, by stopping, NOT acking the cancel to swf, and sending on ToAckStopActivity.
-// * this happens when heartbeats are attempted after a task is timed out or canceled or completed.
-
 const (
 	TaskGone = "Unknown activity"
 )
 
 func (w *ActivityWorker) AddCoordinatedHandler(heartbeatInterval time.Duration, heartbeatErrorThreshold int, handler *CoordinatedActivityHandler) {
-	coordinator := &LongRunningActivityCoordinator{
-		HeartbeatInterval:     heartbeatInterval,
-		HeartbeatErrors:       make(chan error, heartbeatErrorThreshold),
-		ToCancelActivity:      make(chan struct{}),
-		ToAckCancelActivity:   make(chan struct{}),
-		ToStopHeartbeating:    make(chan struct{}),
-		ToAckStopHeartbeating: make(chan struct{}),
-		ToStopActivity:        make(chan struct{}),
-		ToAckStopActivity:     make(chan struct{}),
+
+	ticks := make(chan CoordinatedActivityHandlerTick)
+	startErr := make(chan error)
+
+	handlerTickFunc := func(activityTask *swf.ActivityTask, input interface{}) {
+		go func() {
+			cont, res, err := handler.Tick(activityTask, input)
+			ticks <- CoordinatedActivityHandlerTick{
+				Continue: cont,
+				Result:   res,
+				Error:    err,
+			}
+		}()
 	}
 
+	handlerStartFunc := func(activityTask *swf.ActivityTask, input interface{}) {
+		go func() {
+			err := handler.Start(activityTask, input)
+			if err != nil {
+				startErr <- err
+			} else {
+				handlerTickFunc(activityTask, input)
+			}
+		}()
+	}
+
+	heartbeats := time.Tick(heartbeatInterval)
+
 	handlerFunc := func(activityTask *swf.ActivityTask, input interface{}) {
-		go handler.HandlerFunc(coordinator, activityTask, input)
+		handlerStartFunc(activityTask, input)
 		for {
 			select {
-			case <-time.After(heartbeatInterval):
+			case e := <-startErr:
+				w.fail(activityTask, e)
+				return
+			case tick := <-ticks:
+				if tick.Continue {
+					handlerTickFunc(activityTask, input)
+				} else {
+					if tick.Error != nil {
+						w.fail(activityTask, tick.Error)
+					} else {
+						w.result(activityTask, tick.Result)
+					}
+					return
+				}
+			case <-heartbeats:
 				status, err := w.SWF.RecordActivityTaskHeartbeat(&swf.RecordActivityTaskHeartbeatInput{
 					TaskToken: activityTask.TaskToken,
 				})
 				if err != nil {
 					if ae, ok := err.(aws.APIError); ok && ae.Code == ErrorTypeUnknownResourceFault && strings.Contains(ae.Message, TaskGone) {
 						log.Printf("workflow-id=%s activity-id=%s activity-id=%s at=activity-gone", LS(activityTask.WorkflowExecution.WorkflowID), LS(activityTask.ActivityType.Name), LS(activityTask.ActivityID))
-						coordinator.ToStopActivity <- struct{}{}
-						<-coordinator.ToAckStopActivity
-						log.Printf("workflow-id=%s activity-id=%s activity-id=%s at=stopped-activity-gone", LS(activityTask.WorkflowExecution.WorkflowID), LS(activityTask.ActivityType.Name), LS(activityTask.ActivityID))
+						//wait for the tick to complete before exiting
+						<-ticks
 						return
 					}
 					log.Printf("workflow-id=%s activity-id=%s activity-id=%s at=heartbeat-error error=%s ", LS(activityTask.WorkflowExecution.WorkflowID), LS(activityTask.ActivityType.Name), LS(activityTask.ActivityID), err.Error())
-					coordinator.HeartbeatErrors <- err
 				} else {
+					log.Printf("workflow-id=%s activity-id=%s activity-id=%s at=heartbeat-recorded", LS(activityTask.WorkflowExecution.WorkflowID), LS(activityTask.ActivityType.Name), LS(activityTask.ActivityID))
 					if *status.CancelRequested {
 						log.Printf("workflow-id=%s activity-id=%s activity-id=%s at=activity-cancel-requested", LS(activityTask.WorkflowExecution.WorkflowID), LS(activityTask.ActivityType.Name), LS(activityTask.ActivityID))
-						coordinator.ToCancelActivity <- struct{}{}
-						<-coordinator.ToAckCancelActivity
-						log.Printf("workflow-id=%s activity-id=%s activity-id=%s at=activity-canceled", LS(activityTask.WorkflowExecution.WorkflowID), LS(activityTask.ActivityType.Name), LS(activityTask.ActivityID))
+						//Wait for any tick to finish
+						<-ticks
+						handler.Cancel(activityTask, input)
+						w.canceled(activityTask)
+						log.Printf("workflow-id=%s activity-id=%s activity-id=%s at=activity-canceld", LS(activityTask.WorkflowExecution.WorkflowID), LS(activityTask.ActivityType.Name), LS(activityTask.ActivityID))
 						return
 					}
 				}
-			case <-coordinator.ToStopHeartbeating:
-				log.Printf("workflow-id=%s activity-id=%s activity-id=%s at=stop-heartbeating", LS(activityTask.WorkflowExecution.WorkflowID), LS(activityTask.ActivityType.Name), LS(activityTask.ActivityID))
-				coordinator.ToAckStopHeartbeating <- struct{}{}
-				log.Printf("workflow-id=%s activity-id=%s activity-id=%s at=ack-stop-heartbeating", LS(activityTask.WorkflowExecution.WorkflowID), LS(activityTask.ActivityType.Name), LS(activityTask.ActivityID))
-				return
 			}
 		}
 	}
@@ -81,4 +97,10 @@ func (w *ActivityWorker) AddCoordinatedHandler(heartbeatInterval time.Duration, 
 	}
 
 	w.AddLongRunningHandler(l)
+}
+
+type CoordinatedActivityHandlerTick struct {
+	Continue bool
+	Result   interface{}
+	Error    error
 }

--- a/activity/coordinated_worker.go
+++ b/activity/coordinated_worker.go
@@ -37,7 +37,7 @@ func (w *ActivityWorker) AddCoordinatedHandler(heartbeatInterval time.Duration, 
 			if err != nil {
 				startErr <- err
 			} else {
-                err = w.signalStart(activityTask)
+				err = w.signalStart(activityTask)
 				if err != nil {
 					startErr <- err
 				} else {

--- a/activity/coordinated_worker_test.go
+++ b/activity/coordinated_worker_test.go
@@ -38,7 +38,8 @@ func TestCoordinatedActivityHandler(t *testing.T) {
 		ActivityType: &swf.ActivityType{
 			Name: S("activity"),
 		},
-		Input: S(input),
+		ActivityID: S("id"),
+		Input:      S(input),
 	})
 
 	hc.cont = false
@@ -59,7 +60,8 @@ func TestCoordinatedActivityHandler(t *testing.T) {
 		ActivityType: &swf.ActivityType{
 			Name: S("activity"),
 		},
-		Input: S(input),
+		ActivityID: S("id"),
+		Input:      S(input),
 	})
 
 	time.Sleep(100 * time.Millisecond)
@@ -92,7 +94,8 @@ func TestTypedCoordinatedActivityHandler(t *testing.T) {
 		ActivityType: &swf.ActivityType{
 			Name: S("activity"),
 		},
-		Input: S(input),
+		ActivityID: S("id"),
+		Input:      S(input),
 	})
 
 	hc.cont = false
@@ -113,7 +116,8 @@ func TestTypedCoordinatedActivityHandler(t *testing.T) {
 		ActivityType: &swf.ActivityType{
 			Name: S("activity"),
 		},
-		Input: S(input),
+		ActivityID: S("id"),
+		Input:      S(input),
 	})
 
 	time.Sleep(200 * time.Millisecond)
@@ -130,9 +134,9 @@ type TypedCoordinatedTaskHandler struct {
 	canceled bool
 }
 
-func (c *TypedCoordinatedTaskHandler) Begin(a *swf.ActivityTask, d *TestInput) error {
+func (c *TypedCoordinatedTaskHandler) Begin(a *swf.ActivityTask, d *TestInput) (*TestOutput, error) {
 	c.t.Log("START")
-	return nil
+	return nil, nil
 }
 
 func (c *TypedCoordinatedTaskHandler) Work(a *swf.ActivityTask, d *TestInput) (bool, *TestOutput, error) {
@@ -156,9 +160,9 @@ type TestCoordinatedTaskHandler struct {
 	canceled bool
 }
 
-func (c *TestCoordinatedTaskHandler) Start(a *swf.ActivityTask, d interface{}) error {
+func (c *TestCoordinatedTaskHandler) Start(a *swf.ActivityTask, d interface{}) (interface{}, error) {
 	c.t.Log("START")
-	return nil
+	return nil, nil
 }
 
 func (c *TestCoordinatedTaskHandler) Tick(a *swf.ActivityTask, d interface{}) (bool, interface{}, error) {

--- a/activity/coordinated_worker_test.go
+++ b/activity/coordinated_worker_test.go
@@ -9,17 +9,27 @@ import (
 	. "github.com/sclasen/swfsm/sugar"
 )
 
-func TestNewLongRunningActivityHandler(t *testing.T) {
-	hc := func(c *LongRunningActivityCoordinator, ta *swf.ActivityTask, d *TestInput) {
-		t.Log("HANDLE")
-		c.ToStopHeartbeating <- struct{}{}
-		<-c.ToAckStopHeartbeating
+func TestCoordinatedActivityHandler(t *testing.T) {
+	hc := &TestCoordinatedTaskHandler{
+		t:        t,
+		canceled: false,
 	}
 
-	handler := NewCoordinatedActivityHandler("activity", hc)
+	handler := &CoordinatedActivityHandler{
+		Input:    TestInput{},
+		Activity: "activity",
+		Start:    hc.Start,
+		Tick:     hc.Tick,
+		Cancel:   hc.Cancel,
+	}
 
-	worker := ActivityWorker{}
-	worker.AddCoordinatedHandler(10*time.Second, 100, handler)
+	mockSwf := &MockSWF{}
+	worker := ActivityWorker{
+		SWF: mockSwf,
+	}
+
+	t.Log("test complete")
+	worker.AddCoordinatedHandler(1*time.Second, 100, handler)
 	worker.Init()
 	input, _ := worker.Serializer.Serialize(&TestInput{Name: "Foo"})
 	worker.handleActivityTask(&swf.ActivityTask{
@@ -30,4 +40,138 @@ func TestNewLongRunningActivityHandler(t *testing.T) {
 		},
 		Input: S(input),
 	})
+
+	hc.cont = false
+	time.Sleep(100 * time.Millisecond)
+	if !mockSwf.CompletedSet {
+		t.Fatal("Not Completed")
+	}
+
+	t.Log("test cancel")
+	hc.cont = true
+	mockSwf.CompletedSet = false
+	mockSwf.Completed = nil
+	mockSwf.Canceled = true
+
+	worker.handleActivityTask(&swf.ActivityTask{
+		TaskToken:         S("token"),
+		WorkflowExecution: &swf.WorkflowExecution{},
+		ActivityType: &swf.ActivityType{
+			Name: S("activity"),
+		},
+		Input: S(input),
+	})
+
+	time.Sleep(100 * time.Millisecond)
+	if !hc.canceled {
+		t.Fatal("Not Canceled")
+	}
+
+}
+
+func TestTypedCoordinatedActivityHandler(t *testing.T) {
+	hc := &TypedCoordinatedTaskHandler{
+		t:        t,
+		canceled: false,
+	}
+
+	handler := NewCoordinatedActivityHandler("activity", hc.Begin, hc.Work, hc.Stop)
+
+	mockSwf := &MockSWF{}
+	worker := ActivityWorker{
+		SWF: mockSwf,
+	}
+
+	t.Log("test complete")
+	worker.AddCoordinatedHandler(1*time.Second, 100, handler)
+	worker.Init()
+	input, _ := worker.Serializer.Serialize(&TestInput{Name: "Foo"})
+	worker.handleActivityTask(&swf.ActivityTask{
+		TaskToken:         S("token"),
+		WorkflowExecution: &swf.WorkflowExecution{},
+		ActivityType: &swf.ActivityType{
+			Name: S("activity"),
+		},
+		Input: S(input),
+	})
+
+	hc.cont = false
+	time.Sleep(100 * time.Millisecond)
+	if !mockSwf.CompletedSet {
+		t.Fatal("Not Completed")
+	}
+
+	t.Log("test cancel")
+	hc.cont = true
+	mockSwf.CompletedSet = false
+	mockSwf.Completed = nil
+	mockSwf.Canceled = true
+
+	worker.handleActivityTask(&swf.ActivityTask{
+		TaskToken:         S("token"),
+		WorkflowExecution: &swf.WorkflowExecution{},
+		ActivityType: &swf.ActivityType{
+			Name: S("activity"),
+		},
+		Input: S(input),
+	})
+
+	time.Sleep(200 * time.Millisecond)
+
+	if !hc.canceled {
+		t.Fatal("Not Canceled")
+	}
+
+}
+
+type TypedCoordinatedTaskHandler struct {
+	t        *testing.T
+	cont     bool
+	canceled bool
+}
+
+func (c *TypedCoordinatedTaskHandler) Begin(a *swf.ActivityTask, d *TestInput) error {
+	c.t.Log("START")
+	return nil
+}
+
+func (c *TypedCoordinatedTaskHandler) Work(a *swf.ActivityTask, d *TestInput) (bool, *TestOutput, error) {
+	c.t.Log("TICK")
+	time.Sleep(100 * time.Millisecond)
+	if c.cont {
+		return true, nil, nil
+	}
+	return false, &TestOutput{Name: "done"}, nil
+}
+
+func (c *TypedCoordinatedTaskHandler) Stop(a *swf.ActivityTask, d *TestInput) error {
+	c.t.Log("CANCEL")
+	c.canceled = true
+	return nil
+}
+
+type TestCoordinatedTaskHandler struct {
+	t        *testing.T
+	cont     bool
+	canceled bool
+}
+
+func (c *TestCoordinatedTaskHandler) Start(a *swf.ActivityTask, d interface{}) error {
+	c.t.Log("START")
+	return nil
+}
+
+func (c *TestCoordinatedTaskHandler) Tick(a *swf.ActivityTask, d interface{}) (bool, interface{}, error) {
+	c.t.Log("TICK")
+	time.Sleep(100 * time.Millisecond)
+	if c.cont {
+		return true, nil, nil
+	}
+	return false, &TestOutput{Name: "done"}, nil
+}
+
+func (c *TestCoordinatedTaskHandler) Cancel(a *swf.ActivityTask, d interface{}) error {
+	c.t.Log("CANCEL")
+	c.canceled = true
+	return nil
 }

--- a/activity/coordinated_worker_test.go
+++ b/activity/coordinated_worker_test.go
@@ -29,7 +29,7 @@ func TestCoordinatedActivityHandler(t *testing.T) {
 	}
 
 	t.Log("test complete")
-	worker.AddCoordinatedHandler(1*time.Second, 100, handler)
+	worker.AddCoordinatedHandler(1*time.Second, handler)
 	worker.Init()
 	input, _ := worker.Serializer.Serialize(&TestInput{Name: "Foo"})
 	worker.handleActivityTask(&swf.ActivityTask{
@@ -83,7 +83,7 @@ func TestTypedCoordinatedActivityHandler(t *testing.T) {
 	}
 
 	t.Log("test complete")
-	worker.AddCoordinatedHandler(1*time.Second, 100, handler)
+	worker.AddCoordinatedHandler(1*time.Second, handler)
 	worker.Init()
 	input, _ := worker.Serializer.Serialize(&TestInput{Name: "Foo"})
 	worker.handleActivityTask(&swf.ActivityTask{

--- a/activity/handler.go
+++ b/activity/handler.go
@@ -23,7 +23,7 @@ type LongRunningActivityHandler struct {
 	Input       interface{}
 }
 
-type CoordinatedActivityHandlerStartFunc func(*swf.ActivityTask, interface{}) error
+type CoordinatedActivityHandlerStartFunc func(*swf.ActivityTask, interface{}) (interface{}, error)
 
 type CoordinatedActivityHandlerTickFunc func(*swf.ActivityTask, interface{}) (bool, interface{}, error)
 
@@ -76,7 +76,7 @@ func NewCoordinatedActivityHandler(activity string, start interface{}, tick inte
 	}
 	output := outputType(tick, 1)
 
-	typeCheck(start, []string{"*swf.ActivityTask", input.String()}, []string{"error"})
+	typeCheck(start, []string{"*swf.ActivityTask", input.String()}, []string{output, "error"})
 	typeCheck(tick, []string{"*swf.ActivityTask", input.String()}, []string{"bool", output, "error"})
 	typeCheck(cancel, []string{"*swf.ActivityTask", input.String()}, []string{"error"})
 
@@ -111,9 +111,9 @@ func (m marshalledFunc) longRunningActivityHandlerFunc(task *swf.ActivityTask, i
 	m.v.Call([]reflect.Value{reflect.ValueOf(task), reflect.ValueOf(input)})
 }
 
-func (m marshalledFunc) handleCoordinatedActivityStart(task *swf.ActivityTask, input interface{}) error {
+func (m marshalledFunc) handleCoordinatedActivityStart(task *swf.ActivityTask, input interface{}) (interface{}, error) {
 	ret := m.v.Call([]reflect.Value{reflect.ValueOf(task), reflect.ValueOf(input)})
-	return errorValue(ret[0])
+	return outputValue(ret[0]), errorValue(ret[1])
 }
 
 func (m marshalledFunc) handleCoordinatedActivityTick(task *swf.ActivityTask, input interface{}) (bool, interface{}, error) {

--- a/activity/handler.go
+++ b/activity/handler.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"reflect"
 
-	"time"
-
 	"github.com/awslabs/aws-sdk-go/gen/swf"
 )
 
@@ -25,29 +23,23 @@ type LongRunningActivityHandler struct {
 	Input       interface{}
 }
 
-type CoordinatedActivityHandlerFunc func(*LongRunningActivityCoordinator, *swf.ActivityTask, interface{})
+type CoordinatedActivityHandlerStartFunc func(*swf.ActivityTask, interface{}) error
+
+type CoordinatedActivityHandlerTickFunc func(*swf.ActivityTask, interface{}) (bool, interface{}, error)
+
+type CoordinatedActivityHandlerCancelFunc func(*swf.ActivityTask, interface{}) error
 
 type CoordinatedActivityHandler struct {
-	Activity    string
-	HandlerFunc CoordinatedActivityHandlerFunc
-	Input       interface{}
-}
-
-//LongRunningActivityFunc that creates all the coordination channels, starts heartbeating, and calls into
-type LongRunningActivityCoordinator struct {
-	HeartbeatInterval     time.Duration
-	ToCancelActivity      chan struct{}
-	ToAckCancelActivity   chan struct{}
-	ToStopHeartbeating    chan struct{}
-	ToAckStopHeartbeating chan struct{}
-	ToStopActivity        chan struct{}
-	ToAckStopActivity     chan struct{}
-	HeartbeatErrors       chan error
+	Start    CoordinatedActivityHandlerStartFunc
+	Tick     CoordinatedActivityHandlerTickFunc
+	Cancel   CoordinatedActivityHandlerCancelFunc
+	Input    interface{}
+	Activity string
 }
 
 func NewActivityHandler(activity string, handler interface{}) *ActivityHandler {
 	input := inputType(handler, 1)
-	output := outputType(handler)
+	output := outputType(handler, 0)
 	newType := input
 	if input.Kind() == reflect.Ptr {
 		newType = input.Elem()
@@ -75,19 +67,25 @@ func NewLongRunningActivityHandler(activity string, handler interface{}) *LongRu
 	}
 }
 
-func NewCoordinatedActivityHandler(activity string, handler interface{}) *CoordinatedActivityHandler {
-	input := inputType(handler, 2)
+func NewCoordinatedActivityHandler(activity string, start interface{}, tick interface{}, cancel interface{}) *CoordinatedActivityHandler {
+
+	input := inputType(tick, 1)
 	newType := input
 	if input.Kind() == reflect.Ptr {
 		newType = input.Elem()
 	}
+	output := outputType(tick, 1)
 
-	typeCheck(handler, []string{"*activity.LongRunningActivityCoordinator", "*swf.ActivityTask", input.String()}, []string{})
+	typeCheck(start, []string{"*swf.ActivityTask", input.String()}, []string{"error"})
+	typeCheck(tick, []string{"*swf.ActivityTask", input.String()}, []string{"bool", output, "error"})
+	typeCheck(cancel, []string{"*swf.ActivityTask", input.String()}, []string{"error"})
 
 	return &CoordinatedActivityHandler{
-		Activity:    activity,
-		HandlerFunc: marshalledFunc{reflect.ValueOf(handler)}.handleCoordinatedActivity,
-		Input:       reflect.New(newType).Elem().Interface(),
+		Activity: activity,
+		Start:    marshalledFunc{reflect.ValueOf(start)}.handleCoordinatedActivityStart,
+		Tick:     marshalledFunc{reflect.ValueOf(tick)}.handleCoordinatedActivityTick,
+		Cancel:   marshalledFunc{reflect.ValueOf(cancel)}.handleCoordinatedActivityCancel,
+		Input:    reflect.New(newType).Elem().Interface(),
 	}
 
 }
@@ -113,8 +111,19 @@ func (m marshalledFunc) longRunningActivityHandlerFunc(task *swf.ActivityTask, i
 	m.v.Call([]reflect.Value{reflect.ValueOf(task), reflect.ValueOf(input)})
 }
 
-func (m marshalledFunc) handleCoordinatedActivity(coordinator *LongRunningActivityCoordinator, task *swf.ActivityTask, input interface{}) {
-	m.v.Call([]reflect.Value{reflect.ValueOf(coordinator), reflect.ValueOf(task), reflect.ValueOf(input)})
+func (m marshalledFunc) handleCoordinatedActivityStart(task *swf.ActivityTask, input interface{}) error {
+	ret := m.v.Call([]reflect.Value{reflect.ValueOf(task), reflect.ValueOf(input)})
+	return errorValue(ret[0])
+}
+
+func (m marshalledFunc) handleCoordinatedActivityTick(task *swf.ActivityTask, input interface{}) (bool, interface{}, error) {
+	ret := m.v.Call([]reflect.Value{reflect.ValueOf(task), reflect.ValueOf(input)})
+	return outputValue(ret[0]).(bool), outputValue(ret[1]), errorValue(ret[2])
+}
+
+func (m marshalledFunc) handleCoordinatedActivityCancel(task *swf.ActivityTask, input interface{}) error {
+	ret := m.v.Call([]reflect.Value{reflect.ValueOf(task), reflect.ValueOf(input)})
+	return errorValue(ret[0])
 }
 
 func outputValue(v reflect.Value) interface{} {
@@ -145,12 +154,12 @@ func inputType(handler interface{}, idx int) reflect.Type {
 	return t.In(idx)
 }
 
-func outputType(handler interface{}) string {
+func outputType(handler interface{}, idx int) string {
 	t := reflect.TypeOf(handler)
 	if reflect.Func != t.Kind() {
 		panic(fmt.Sprintf("kind was %v, not Func", t.Kind()))
 	}
-	return t.Out(0).String()
+	return t.Out(idx).String()
 }
 
 func typeCheck(typedFunc interface{}, in []string, out []string) {

--- a/activity/worker.go
+++ b/activity/worker.go
@@ -214,6 +214,7 @@ func (h *ActivityWorker) fail(task *swf.ActivityTask, err error) {
 
 func (h *ActivityWorker) signalStart(activityTask *swf.ActivityTask) error {
 	return h.SWF.SignalWorkflowExecution(&swf.SignalWorkflowExecutionInput{
+		Domain: S(h.Domain),
 		WorkflowID: activityTask.WorkflowExecution.WorkflowID,
 		SignalName: S(fsm.ActivityStartedSignal),
 	})

--- a/activity/worker.go
+++ b/activity/worker.go
@@ -214,7 +214,7 @@ func (h *ActivityWorker) fail(task *swf.ActivityTask, err error) {
 
 func (h *ActivityWorker) signalStart(activityTask *swf.ActivityTask) error {
 	return h.SWF.SignalWorkflowExecution(&swf.SignalWorkflowExecutionInput{
-		Domain: S(h.Domain),
+		Domain:     S(h.Domain),
 		WorkflowID: activityTask.WorkflowExecution.WorkflowID,
 		SignalName: S(fsm.ActivityStartedSignal),
 	})

--- a/activity/worker.go
+++ b/activity/worker.go
@@ -247,11 +247,12 @@ func (h *ActivityWorker) done(resp *swf.ActivityTask, result *string) {
 	}
 }
 
-func (h *ActivityWorker) canceled(resp *swf.ActivityTask) {
+func (h *ActivityWorker) canceled(resp *swf.ActivityTask, details *string) {
 	log.Printf("workflow-id=%s activity-id=%s activity-id=%s at=cancled", LS(resp.WorkflowExecution.WorkflowID), LS(resp.ActivityType.Name), LS(resp.ActivityID))
 
 	canceledErr := h.SWF.RespondActivityTaskCanceled(&swf.RespondActivityTaskCanceledInput{
 		TaskToken: resp.TaskToken,
+		Details:   details,
 	})
 	if canceledErr != nil {
 		log.Printf("workflow-id=%s activity-id=%s activity-id=%s at=canceled-response-fail error=%s ", LS(resp.WorkflowExecution.WorkflowID), LS(resp.ActivityType.Name), LS(resp.ActivityID), canceledErr.Error())

--- a/activity/worker_test.go
+++ b/activity/worker_test.go
@@ -49,10 +49,9 @@ func (m *MockSWF) GetWorkflowExecutionHistory(req *swf.GetWorkflowExecutionHisto
 	return m.History, nil
 }
 
-func (m *MockSWF) SignalWorkflowExecution(req *swf.SignalWorkflowExecutionInput) (err error){
+func (m *MockSWF) SignalWorkflowExecution(req *swf.SignalWorkflowExecutionInput) (err error) {
 	return nil
 }
-
 
 func ExampleActivityWorker() {
 

--- a/activity/worker_test.go
+++ b/activity/worker_test.go
@@ -21,10 +21,13 @@ type MockSWF struct {
 	Completed    *string
 	CompletedSet bool
 	History      *swf.History
+	Canceled     bool
 }
 
-func (*MockSWF) RecordActivityTaskHeartbeat(req *swf.RecordActivityTaskHeartbeatInput) (resp *swf.ActivityTaskStatus, err error) {
-	return nil, nil
+func (m *MockSWF) RecordActivityTaskHeartbeat(req *swf.RecordActivityTaskHeartbeatInput) (resp *swf.ActivityTaskStatus, err error) {
+	return &swf.ActivityTaskStatus{
+		CancelRequested: &m.Canceled,
+	}, nil
 }
 func (*MockSWF) RespondActivityTaskCanceled(req *swf.RespondActivityTaskCanceledInput) (err error) {
 	return nil

--- a/activity/worker_test.go
+++ b/activity/worker_test.go
@@ -49,6 +49,11 @@ func (m *MockSWF) GetWorkflowExecutionHistory(req *swf.GetWorkflowExecutionHisto
 	return m.History, nil
 }
 
+func (m *MockSWF) SignalWorkflowExecution(req *swf.SignalWorkflowExecutionInput) (err error){
+	return nil
+}
+
+
 func ExampleActivityWorker() {
 
 	var swfOps SWFOps

--- a/fsm/correlator.go
+++ b/fsm/correlator.go
@@ -18,6 +18,7 @@ type EventCorrelator struct {
 	Signals          map[string]*SignalInfo   //schedueledEventId -> info
 	SignalAttempts   map[string]int           //? workflowID + signalName -> attempts
 	Timers           map[string]*TimerInfo    //startedEventID -> info
+	Serializer       StateSerializer
 }
 
 // ActivityInfo holds the ActivityID and ActivityType for an activity
@@ -199,7 +200,18 @@ func (a *EventCorrelator) getID(h swf.HistoryEvent) (id string) {
 		if h.TimerCanceledEventAttributes != nil {
 			id = a.key(h.TimerCanceledEventAttributes.StartedEventID)
 		}
-
+	case swf.EventTypeWorkflowExecutionSignaled:
+		event := h.WorkflowExecutionSignaledEventAttributes
+		if event != nil && event.SignalName != nil && event.Input != nil {
+			switch *event.SignalName {
+			case ActivityStartedSignal, ActivityUpdatedSignal:
+				state := new(SerializedActivityState)
+				a.Serializer.Deserialize(*event.Input, state)
+				id = state.ActivityID
+			default:
+				id = a.key(event.ExternalInitiatedEventID)
+			}
+		}
 	}
 	return
 }

--- a/fsm/correlator.go
+++ b/fsm/correlator.go
@@ -178,6 +178,11 @@ func (a *EventCorrelator) getID(h swf.HistoryEvent) (id string) {
 		if h.ActivityTaskCanceledEventAttributes != nil {
 			id = a.key(h.ActivityTaskCanceledEventAttributes.ScheduledEventID)
 		}
+	//might want to get info on started too
+	case swf.EventTypeActivityTaskStarted:
+		if h.ActivityTaskStartedEventAttributes != nil {
+			id = a.key(h.ActivityTaskStartedEventAttributes.ScheduledEventID)
+		}
 	case swf.EventTypeExternalWorkflowExecutionSignaled:
 		if h.ExternalWorkflowExecutionSignaledEventAttributes != nil {
 			id = a.key(h.ExternalWorkflowExecutionSignaledEventAttributes.InitiatedEventID)

--- a/fsm/correlator_test.go
+++ b/fsm/correlator_test.go
@@ -328,6 +328,7 @@ func TestFSMContextActivityTracking(t *testing.T) {
 
 func TestCountActivityAttemtps(t *testing.T) {
 	c := new(EventCorrelator)
+	c.Serializer = JSONStateSerializer{}
 
 	start := func(eventId int) swf.HistoryEvent {
 		return EventFromPayload(eventId, &swf.ActivityTaskScheduledEventAttributes{
@@ -393,6 +394,7 @@ func TestSignalTracking(t *testing.T) {
 	})
 
 	c := new(EventCorrelator)
+	c.Serializer = JSONStateSerializer{}
 
 	c.Track(start)
 	//track happens in FSM after Decider
@@ -442,6 +444,7 @@ func TestTimerTracking(t *testing.T) {
 	})
 
 	c := new(EventCorrelator)
+	c.Serializer = JSONStateSerializer{}
 
 	c.Track(start)
 	c.Track(timerStart)

--- a/fsm/deciders.go
+++ b/fsm/deciders.go
@@ -215,6 +215,17 @@ func OnContinued(deciders ...Decider) Decider {
 	}
 }
 
+func OnContinueFailed(deciders ...Decider) Decider {
+	return func(ctx *FSMContext, h swf.HistoryEvent, data interface{}) Outcome {
+		switch *h.EventType {
+		case swf.EventTypeContinueAsNewWorkflowExecutionFailed:
+			logf(ctx, "at=on-continuefailed")
+			return NewComposedDecider(deciders...)(ctx, h, data)
+		}
+		return ctx.Pass()
+	}
+}
+
 func OnStartedOrContinued(deciders ...Decider) Decider {
 	return func(ctx *FSMContext, h swf.HistoryEvent, data interface{}) Outcome {
 		switch *h.EventType {

--- a/fsm/deciders.go
+++ b/fsm/deciders.go
@@ -204,33 +204,11 @@ func OnStarted(deciders ...Decider) Decider {
 	}
 }
 
-func OnContinued(deciders ...Decider) Decider {
-	return func(ctx *FSMContext, h swf.HistoryEvent, data interface{}) Outcome {
-		switch *h.EventType {
-		case swf.EventTypeWorkflowExecutionContinuedAsNew:
-			logf(ctx, "at=on-continued")
-			return NewComposedDecider(deciders...)(ctx, h, data)
-		}
-		return ctx.Pass()
-	}
-}
-
 func OnContinueFailed(deciders ...Decider) Decider {
 	return func(ctx *FSMContext, h swf.HistoryEvent, data interface{}) Outcome {
 		switch *h.EventType {
 		case swf.EventTypeContinueAsNewWorkflowExecutionFailed:
 			logf(ctx, "at=on-continuefailed")
-			return NewComposedDecider(deciders...)(ctx, h, data)
-		}
-		return ctx.Pass()
-	}
-}
-
-func OnStartedOrContinued(deciders ...Decider) Decider {
-	return func(ctx *FSMContext, h swf.HistoryEvent, data interface{}) Outcome {
-		switch *h.EventType {
-		case swf.EventTypeWorkflowExecutionContinuedAsNew, swf.EventTypeWorkflowExecutionStarted:
-			logf(ctx, "at=on-started-or-continued")
 			return NewComposedDecider(deciders...)(ctx, h, data)
 		}
 		return ctx.Pass()

--- a/fsm/deciders.go
+++ b/fsm/deciders.go
@@ -204,12 +204,22 @@ func OnStarted(deciders ...Decider) Decider {
 	}
 }
 
-// OnStarted builds a composed decider that fires on swf.EventTypeWorkflowExecutionStarted.
 func OnContinued(deciders ...Decider) Decider {
 	return func(ctx *FSMContext, h swf.HistoryEvent, data interface{}) Outcome {
 		switch *h.EventType {
 		case swf.EventTypeWorkflowExecutionContinuedAsNew:
 			logf(ctx, "at=on-continued")
+			return NewComposedDecider(deciders...)(ctx, h, data)
+		}
+		return ctx.Pass()
+	}
+}
+
+func OnStartedOrContinued(deciders ...Decider) Decider {
+	return func(ctx *FSMContext, h swf.HistoryEvent, data interface{}) Outcome {
+		switch *h.EventType {
+		case swf.EventTypeWorkflowExecutionContinuedAsNew, swf.EventTypeWorkflowExecutionStarted:
+			logf(ctx, "at=on-started-or-continued")
 			return NewComposedDecider(deciders...)(ctx, h, data)
 		}
 		return ctx.Pass()

--- a/fsm/deciders.go
+++ b/fsm/deciders.go
@@ -204,6 +204,18 @@ func OnStarted(deciders ...Decider) Decider {
 	}
 }
 
+// OnStarted builds a composed decider that fires on swf.EventTypeWorkflowExecutionStarted.
+func OnContinued(deciders ...Decider) Decider {
+	return func(ctx *FSMContext, h swf.HistoryEvent, data interface{}) Outcome {
+		switch *h.EventType {
+		case swf.EventTypeWorkflowExecutionContinuedAsNew:
+			logf(ctx, "at=on-continued")
+			return NewComposedDecider(deciders...)(ctx, h, data)
+		}
+		return ctx.Pass()
+	}
+}
+
 // OnChildStarted builds a composed decider that fires on swf.EventTypeChildWorkflowExecutionStarted.
 func OnChildStarted(deciders ...Decider) Decider {
 	return func(ctx *FSMContext, h swf.HistoryEvent, data interface{}) Outcome {
@@ -349,6 +361,17 @@ func OnActivityFailedTimedOutCanceled(activityName string, deciders ...Decider) 
 		swf.EventTypeActivityTaskTimedOut,
 		swf.EventTypeActivityTaskCanceled,
 	}, deciders...)
+}
+
+func OnWorkflowCancelRequested(deciders ...Decider) Decider {
+	return func(ctx *FSMContext, h swf.HistoryEvent, data interface{}) Outcome {
+		switch *h.EventType {
+		case swf.EventTypeWorkflowExecutionCancelRequested:
+			logf(ctx, "at=on-wokrflow-execution-cancel-requested")
+			return NewComposedDecider(deciders...)(ctx, h, data)
+		}
+		return ctx.Pass()
+	}
 }
 
 // AddDecision adds a single decision to a ContinueDecider outcome

--- a/fsm/deciders_test.go
+++ b/fsm/deciders_test.go
@@ -221,6 +221,7 @@ func TestStay(t *testing.T) {}
 func testContextWithActivity(scheduledEventId int, event *swf.ActivityTaskScheduledEventAttributes) func() *FSMContext {
 	return func() *FSMContext {
 		correlator := &EventCorrelator{}
+		correlator.Serializer = JSONStateSerializer{}
 		correlator.Track(s.EventFromPayload(scheduledEventId, event))
 		ctx := deciderTestContext()
 		ctx.eventCorrelator = correlator

--- a/fsm/fsm.go
+++ b/fsm/fsm.go
@@ -581,12 +581,16 @@ func (f *FSM) findSerializedState(events []swf.HistoryEvent) (*SerializedState, 
 func (f *FSM) findSerializedEventCorrelator(events []swf.HistoryEvent) (*EventCorrelator, error) {
 	for _, event := range events {
 		if f.isCorrelatorMarker(event) {
-			correlator := &EventCorrelator{}
+			correlator := &EventCorrelator{
+				Serializer: f.systemSerializer,
+			}
 			err := f.Serializer.Deserialize(*event.MarkerRecordedEventAttributes.Details, correlator)
 			return correlator, err
 		}
 	}
-	return &EventCorrelator{}, nil
+	return &EventCorrelator{
+		Serializer: f.systemSerializer,
+	}, nil
 }
 
 func (f *FSM) findSerializedErrorState(events []swf.HistoryEvent) (*SerializedErrorState, error) {

--- a/fsm/fsm.go
+++ b/fsm/fsm.go
@@ -525,7 +525,16 @@ func (f *FSM) EventData(event swf.HistoryEvent, eventData interface{}) {
 		case swf.EventTypeChildWorkflowExecutionCompleted:
 			serialized = *event.ChildWorkflowExecutionCompletedEventAttributes.Result
 		case swf.EventTypeWorkflowExecutionSignaled:
-			serialized = *event.WorkflowExecutionSignaledEventAttributes.Input
+			switch *event.WorkflowExecutionSignaledEventAttributes.SignalName {
+			case ActivityStartedSignal, ActivityUpdatedSignal:
+				state := new(SerializedActivityState)
+				f.systemSerializer.Deserialize(*event.WorkflowExecutionSignaledEventAttributes.Input, state)
+				if state.Input != nil {
+					serialized = *state.Input
+				}
+			default:
+				serialized = *event.WorkflowExecutionSignaledEventAttributes.Input
+			}
 		case swf.EventTypeWorkflowExecutionStarted:
 			serialized = *event.WorkflowExecutionStartedEventAttributes.Input
 		case swf.EventTypeWorkflowExecutionContinuedAsNew:

--- a/fsm/fsm_models.go
+++ b/fsm/fsm_models.go
@@ -30,8 +30,10 @@ const (
 	FSMErrorStateDeserialization = "ErrorStateDeserialization"
 	//the FSM encountered an erryor while deserializaing stateData
 	FSMErrorCorrelationDeserialization = "ErrorCorrelationDeserialization"
-	//Signal that kicks the workflow so it will see ActivityTaskStarted events, can be ignored
+	//Signal sent when a Long Lived Worker Start()
 	ActivityStartedSignal = "FSM.ActivityStarted"
+	//Signal send when long Lived worker sends an update from Work()
+	ActivityUpdatedSignal = "FSM.ActivityUpdated"
 )
 
 // Decider decides an Outcome based on an event and the current data for an
@@ -326,4 +328,10 @@ type SerializedErrorState struct {
 	EarliestUnprocessedEventID int64
 	LatestUnprocessedEventID   int64
 	ErrorEvent                 swf.HistoryEvent
+}
+
+//Payload of Signals ActivityStartedSignal and ActivityUpdatedSignal
+type SerializedActivityState struct {
+	ActivityID string
+	Input      *string
 }

--- a/fsm/fsm_models.go
+++ b/fsm/fsm_models.go
@@ -30,6 +30,8 @@ const (
 	FSMErrorStateDeserialization = "ErrorStateDeserialization"
 	//the FSM encountered an erryor while deserializaing stateData
 	FSMErrorCorrelationDeserialization = "ErrorCorrelationDeserialization"
+	//Signal that kicks the workflow so it will see ActivityTaskStarted events, can be ignored
+	ActivityStartedSignal = "FSM.ActivityStarted"
 )
 
 // Decider decides an Outcome based on an event and the current data for an

--- a/fsm/fsm_test.go
+++ b/fsm/fsm_test.go
@@ -539,7 +539,7 @@ func testContext(fsm *FSM) *FSMContext {
 		fsm,
 		swf.WorkflowType{Name: S("test-workflow"), Version: S("1")},
 		swf.WorkflowExecution{WorkflowID: S("test-workflow-1"), RunID: S("123123")},
-		&EventCorrelator{},
+		&EventCorrelator{Serializer: JSONStateSerializer{}},
 		"InitialState", &TestData{}, 0,
 	)
 }

--- a/migrator/migrator.go
+++ b/migrator/migrator.go
@@ -61,10 +61,6 @@ func (t *TypesMigrator) Migrate() {
 	)
 }
 
-type Migration interface {
-	Migrate()
-}
-
 func ParallelMigrate(migrators ...func()) {
 	fail := make(chan interface{})
 	done := make(chan struct{}, len(migrators))

--- a/migrator/migrator.go
+++ b/migrator/migrator.go
@@ -86,7 +86,6 @@ func ParallelMigrate(migrators ...Migration) {
 		case e := <-fail:
 			log.Panicf("migrator failed: %v", e)
 		}
-		<-done
 	}
 }
 

--- a/migrator/migrator.go
+++ b/migrator/migrator.go
@@ -55,9 +55,9 @@ func (t *TypesMigrator) Migrate() {
 
 	t.DomainMigrator.Migrate()
 	ParallelMigrate(
-		t.WorkflowTypeMigrator,
-		t.ActivityTypeMigrator,
-		t.StreamMigrator,
+		t.WorkflowTypeMigrator.Migrate,
+		t.ActivityTypeMigrator.Migrate,
+		t.StreamMigrator.Migrate,
 	)
 }
 
@@ -65,7 +65,7 @@ type Migration interface {
 	Migrate()
 }
 
-func ParallelMigrate(migrators ...Migration) {
+func ParallelMigrate(migrators ...func()) {
 	fail := make(chan interface{})
 	done := make(chan struct{}, len(migrators))
 	for _, m := range migrators {
@@ -76,7 +76,7 @@ func ParallelMigrate(migrators ...Migration) {
 					fail <- r
 				}
 			}()
-			migrator.Migrate()
+			migrator()
 			done <- struct{}{}
 		}()
 	}

--- a/testing/listener.go
+++ b/testing/listener.go
@@ -25,16 +25,20 @@ type TestConfig struct {
 	Workers               []*activity.ActivityWorker
 	StubbedWorkflows      []string
 	ShortStubbedWorkflows []string
+	DefaultWaitTimeout    int
 }
 
 func NewTestListener(t TestConfig) *TestListener {
+	if t.DefaultWaitTimeout == 0 {
+		t.DefaultWaitTimeout = 10
+	}
 
 	tl := &TestListener{
 		decisionOutcomes: make(chan DecisionOutcome, 1000),
 		historyInterest:  make(map[string]chan swf.HistoryEvent, 1000),
 		decisionInterest: make(map[string]chan swf.Decision, 1000),
 		stateInterest:    make(map[string]chan string, 1000),
-		DefaultWait:      10 * time.Second,
+		DefaultWait:      time.Duration(t.DefaultWaitTimeout) * time.Second,
 		testAdapter:      t.Testing,
 		TestID:           uuid.New(),
 	}

--- a/testing/stubs.go
+++ b/testing/stubs.go
@@ -98,8 +98,6 @@ func TestInterceptor(testID string, stubbedWorkflows, stubbedShortWorkflows []st
 					}
 				case swf.DecisionTypeScheduleActivityTask:
 					d.ScheduleActivityTaskDecisionAttributes.TaskList = &swf.TaskList{Name: S(*d.ScheduleActivityTaskDecisionAttributes.TaskList.Name + testID)}
-				case swf.DecisionTypeContinueAsNewWorkflowExecution:
-					d.ContinueAsNewWorkflowExecutionDecisionAttributes.TaskList = &swf.TaskList{Name: S(*d.ContinueAsNewWorkflowExecutionDecisionAttributes.TaskList.Name + testID)}
 				}
 			}
 		},

--- a/testing/stubs.go
+++ b/testing/stubs.go
@@ -98,6 +98,8 @@ func TestInterceptor(testID string, stubbedWorkflows, stubbedShortWorkflows []st
 					}
 				case swf.DecisionTypeScheduleActivityTask:
 					d.ScheduleActivityTaskDecisionAttributes.TaskList = &swf.TaskList{Name: S(*d.ScheduleActivityTaskDecisionAttributes.TaskList.Name + testID)}
+				case swf.DecisionTypeContinueAsNewWorkflowExecution:
+					d.ContinueAsNewWorkflowExecutionDecisionAttributes.TaskList = &swf.TaskList{Name: S(*d.ContinueAsNewWorkflowExecutionDecisionAttributes.TaskList.Name + testID)}
 				}
 			}
 		},


### PR DESCRIPTION
CoordinatedActivityHandlers are now constructed from 3 funcs.  No more convoluted LongRunningActivityCoordinator mess-o-channels

* Start: start the activity, when this returns, an ActivityStartedSignal is sent to the workflow, which will also let it see the ActivityTaskStartedEvent (which doesnt trigger a decision)
* Work: Do some piece of work, but dont block forever. return true,nil,nil if you want to keep going and Work will be called again. Return false, result, error if you want to finish/fail the activity. This gives an opportunity for the coordinator to cancel the work if necessary after each Tick.
* Cancel: Called after Work yields when the activity has been canceled. Lets you shutdown the activity before RespondActivityTaskCanceled is called.

/cc @ryanbrainard @fabiokung 