### PR TITLE
Activity Task Resumption

### DIFF
--- a/activity/coordinated_worker_test.go
+++ b/activity/coordinated_worker_test.go
@@ -32,7 +32,7 @@ func TestCoordinatedActivityHandler(t *testing.T) {
 	worker.AddCoordinatedHandler(1*time.Second, handler)
 	worker.Init()
 	input, _ := worker.Serializer.Serialize(&TestInput{Name: "Foo"})
-	worker.handleActivityTask(&swf.ActivityTask{
+	worker.handleActivityTask(&ActivityContext{Task: &swf.ActivityTask{
 		TaskToken:         S("token"),
 		WorkflowExecution: &swf.WorkflowExecution{},
 		ActivityType: &swf.ActivityType{
@@ -40,7 +40,7 @@ func TestCoordinatedActivityHandler(t *testing.T) {
 		},
 		ActivityID: S("id"),
 		Input:      S(input),
-	})
+	}})
 
 	hc.cont = false
 	time.Sleep(100 * time.Millisecond)
@@ -54,7 +54,7 @@ func TestCoordinatedActivityHandler(t *testing.T) {
 	mockSwf.Completed = nil
 	mockSwf.Canceled = true
 
-	worker.handleActivityTask(&swf.ActivityTask{
+	worker.handleActivityTask(&ActivityContext{Task: &swf.ActivityTask{
 		TaskToken:         S("token"),
 		WorkflowExecution: &swf.WorkflowExecution{},
 		ActivityType: &swf.ActivityType{
@@ -62,7 +62,7 @@ func TestCoordinatedActivityHandler(t *testing.T) {
 		},
 		ActivityID: S("id"),
 		Input:      S(input),
-	})
+	}})
 
 	time.Sleep(100 * time.Millisecond)
 	if !hc.canceled {
@@ -88,7 +88,7 @@ func TestTypedCoordinatedActivityHandler(t *testing.T) {
 	worker.AddCoordinatedHandler(1*time.Second, handler)
 	worker.Init()
 	input, _ := worker.Serializer.Serialize(&TestInput{Name: "Foo"})
-	worker.handleActivityTask(&swf.ActivityTask{
+	worker.handleActivityTask(&ActivityContext{Task: &swf.ActivityTask{
 		TaskToken:         S("token"),
 		WorkflowExecution: &swf.WorkflowExecution{},
 		ActivityType: &swf.ActivityType{
@@ -96,7 +96,7 @@ func TestTypedCoordinatedActivityHandler(t *testing.T) {
 		},
 		ActivityID: S("id"),
 		Input:      S(input),
-	})
+	}})
 
 	hc.cont = false
 	time.Sleep(100 * time.Millisecond)
@@ -110,7 +110,7 @@ func TestTypedCoordinatedActivityHandler(t *testing.T) {
 	mockSwf.Completed = nil
 	mockSwf.Canceled = true
 
-	worker.handleActivityTask(&swf.ActivityTask{
+	worker.handleActivityTask(&ActivityContext{Task: &swf.ActivityTask{
 		TaskToken:         S("token"),
 		WorkflowExecution: &swf.WorkflowExecution{},
 		ActivityType: &swf.ActivityType{
@@ -118,7 +118,7 @@ func TestTypedCoordinatedActivityHandler(t *testing.T) {
 		},
 		ActivityID: S("id"),
 		Input:      S(input),
-	})
+	}})
 
 	time.Sleep(200 * time.Millisecond)
 
@@ -134,12 +134,12 @@ type TypedCoordinatedTaskHandler struct {
 	canceled bool
 }
 
-func (c *TypedCoordinatedTaskHandler) Begin(a *swf.ActivityTask, d *TestInput) (*TestOutput, error) {
+func (c *TypedCoordinatedTaskHandler) Begin(a *ActivityContext, d *TestInput) (*TestOutput, error) {
 	c.t.Log("START")
 	return nil, nil
 }
 
-func (c *TypedCoordinatedTaskHandler) Work(a *swf.ActivityTask, d *TestInput) (bool, *TestOutput, error) {
+func (c *TypedCoordinatedTaskHandler) Work(a *ActivityContext, d *TestInput) (bool, *TestOutput, error) {
 	c.t.Log("TICK")
 	time.Sleep(100 * time.Millisecond)
 	if c.cont {
@@ -148,7 +148,7 @@ func (c *TypedCoordinatedTaskHandler) Work(a *swf.ActivityTask, d *TestInput) (b
 	return false, &TestOutput{Name: "done"}, nil
 }
 
-func (c *TypedCoordinatedTaskHandler) Stop(a *swf.ActivityTask, d *TestInput) error {
+func (c *TypedCoordinatedTaskHandler) Stop(a *ActivityContext, d *TestInput) error {
 	c.t.Log("CANCEL")
 	c.canceled = true
 	return nil
@@ -160,12 +160,12 @@ type TestCoordinatedTaskHandler struct {
 	canceled bool
 }
 
-func (c *TestCoordinatedTaskHandler) Start(a *swf.ActivityTask, d interface{}) (interface{}, error) {
+func (c *TestCoordinatedTaskHandler) Start(a *ActivityContext, d interface{}) (interface{}, error) {
 	c.t.Log("START")
 	return nil, nil
 }
 
-func (c *TestCoordinatedTaskHandler) Tick(a *swf.ActivityTask, d interface{}) (bool, interface{}, error) {
+func (c *TestCoordinatedTaskHandler) Tick(a *ActivityContext, d interface{}) (bool, interface{}, error) {
 	c.t.Log("TICK")
 	time.Sleep(100 * time.Millisecond)
 	if c.cont {
@@ -174,7 +174,7 @@ func (c *TestCoordinatedTaskHandler) Tick(a *swf.ActivityTask, d interface{}) (b
 	return false, &TestOutput{Name: "done"}, nil
 }
 
-func (c *TestCoordinatedTaskHandler) Cancel(a *swf.ActivityTask, d interface{}) error {
+func (c *TestCoordinatedTaskHandler) Cancel(a *ActivityContext, d interface{}) error {
 	c.t.Log("CANCEL")
 	c.canceled = true
 	return nil

--- a/activity/dispatchers_test.go
+++ b/activity/dispatchers_test.go
@@ -4,8 +4,6 @@ import (
 	"sync/atomic"
 	"testing"
 
-	"github.com/awslabs/aws-sdk-go/gen/swf"
-
 	"time"
 )
 
@@ -21,11 +19,11 @@ func TestBoundedGoroutineDispatcher(t *testing.T) {
 }
 
 func testDispatcher(dispatcher ActivityTaskDispatcher, t *testing.T) {
-	task := &swf.ActivityTask{}
+	task := &ActivityContext{}
 	tasksHandled := int32(0)
 	totalTasks := int32(1000)
 	done := make(chan struct{}, 1)
-	handler := func(d *swf.ActivityTask) {
+	handler := func(d *ActivityContext) {
 		handled := atomic.AddInt32(&tasksHandled, 1)
 		if handled == totalTasks {
 			done <- struct{}{}

--- a/activity/handler_test.go
+++ b/activity/handler_test.go
@@ -4,13 +4,11 @@ import (
 	"testing"
 
 	"time"
-
-	"github.com/awslabs/aws-sdk-go/gen/swf"
 )
 
 func TestHandler(t *testing.T) {
 	handler := NewActivityHandler("activity", Handler)
-	ret, err := handler.HandlerFunc(&swf.ActivityTask{}, &TestInput{Name: "testIn"})
+	ret, err := handler.HandlerFunc(&ActivityContext{}, &TestInput{Name: "testIn"})
 	if ret.(*TestOutput).Name != "testInOut" {
 		t.Fatal("Not testInOut")
 	}
@@ -19,17 +17,17 @@ func TestHandler(t *testing.T) {
 		t.Fatal("err not nil")
 	}
 
-	handler.HandlerFunc(&swf.ActivityTask{}, handler.ZeroInput())
+	handler.HandlerFunc(&ActivityContext{}, handler.ZeroInput())
 
 	stringHandler := NewActivityHandler("activity", StringHandler)
-	ret, _ = stringHandler.HandlerFunc(&swf.ActivityTask{}, "foo")
+	ret, _ = stringHandler.HandlerFunc(&ActivityContext{}, "foo")
 	if ret.(string) != "fooOut" {
 		t.Fatal("string not fooOut")
 	}
 
 	handled := make(chan struct{}, 1)
 	longhandler := NewLongRunningActivityHandler("activity", LongHandler(handled))
-	longhandler.HandlerFunc(&swf.ActivityTask{}, &TestInput{Name: "testIn"})
+	longhandler.HandlerFunc(&ActivityContext{}, &TestInput{Name: "testIn"})
 	select {
 	case <-handled:
 		t.Log("handled")
@@ -38,7 +36,7 @@ func TestHandler(t *testing.T) {
 	}
 
 	nilHandler := NewActivityHandler("activity", NilHandler)
-	ret, err = nilHandler.HandlerFunc(&swf.ActivityTask{}, &TestInput{Name: "testIn"})
+	ret, err = nilHandler.HandlerFunc(&ActivityContext{}, &TestInput{Name: "testIn"})
 	if err != nil {
 		t.Fatal(ret, err)
 	}
@@ -49,21 +47,21 @@ func TestHandler(t *testing.T) {
 
 }
 
-func Handler(task *swf.ActivityTask, input *TestInput) (*TestOutput, error) {
+func Handler(task *ActivityContext, input *TestInput) (*TestOutput, error) {
 	return &TestOutput{Name: input.Name + "Out"}, nil
 }
 
-func NilHandler(task *swf.ActivityTask, input *TestInput) (*TestOutput, error) {
+func NilHandler(task *ActivityContext, input *TestInput) (*TestOutput, error) {
 	return nil, nil
 }
 
-func LongHandler(handled chan struct{}) func(task *swf.ActivityTask, input *TestInput) {
-	return func(task *swf.ActivityTask, input *TestInput) {
+func LongHandler(handled chan struct{}) func(task *ActivityContext, input *TestInput) {
+	return func(task *ActivityContext, input *TestInput) {
 		handled <- struct{}{}
 	}
 }
 
-func StringHandler(task *swf.ActivityTask, input string) (string, error) {
+func StringHandler(task *ActivityContext, input string) (string, error) {
 	return input + "Out", nil
 }
 

--- a/activity/interceptors.go
+++ b/activity/interceptors.go
@@ -1,39 +1,35 @@
 package activity
 
-import (
-	"github.com/awslabs/aws-sdk-go/gen/swf"
-)
-
 //ActivityInterceptor allows manipulation of the decision task and the outcome at key points in the task lifecycle.
 type ActivityInterceptor interface {
-	BeforeTask(decision *swf.ActivityTask)
-	AfterTaskComplete(decision *swf.ActivityTask, result interface{})
-	AfterTaskFailed(decision *swf.ActivityTask, err error)
+	BeforeTask(decision *ActivityContext)
+	AfterTaskComplete(decision *ActivityContext, result interface{})
+	AfterTaskFailed(decision *ActivityContext, err error)
 }
 
 //FuncInterceptor is a ActivityInterceptor that you can set handler funcs on. if any are unset, they are no-ops.
 type FuncInterceptor struct {
-	BeforeTaskFn        func(decision *swf.ActivityTask)
-	AfterTaskCompleteFn func(decision *swf.ActivityTask, result interface{})
-	AfterTaskFailedFn   func(decision *swf.ActivityTask, err error)
+	BeforeTaskFn        func(decision *ActivityContext)
+	AfterTaskCompleteFn func(decision *ActivityContext, result interface{})
+	AfterTaskFailedFn   func(decision *ActivityContext, err error)
 }
 
 //BeforeTask runs the BeforeTaskFn if not nil
-func (i *FuncInterceptor) BeforeTask(activity *swf.ActivityTask) {
+func (i *FuncInterceptor) BeforeTask(activity *ActivityContext) {
 	if i.BeforeTaskFn != nil {
 		i.BeforeTaskFn(activity)
 	}
 }
 
 //AfterTaskComplete runs the AfterTaskCompleteFn if not nil
-func (i *FuncInterceptor) AfterTaskComplete(activity *swf.ActivityTask, result interface{}) {
+func (i *FuncInterceptor) AfterTaskComplete(activity *ActivityContext, result interface{}) {
 	if i.AfterTaskCompleteFn != nil {
 		i.AfterTaskCompleteFn(activity, result)
 	}
 }
 
 //AfterTaskFailed runs the AfterTaskFailedFn if not nil
-func (i *FuncInterceptor) AfterTaskFailed(activity *swf.ActivityTask, err error) {
+func (i *FuncInterceptor) AfterTaskFailed(activity *ActivityContext, err error) {
 	if i.AfterTaskFailedFn != nil {
 		i.AfterTaskFailedFn(activity, err)
 	}

--- a/activity/interceptors_test.go
+++ b/activity/interceptors_test.go
@@ -19,13 +19,13 @@ func TestInterceptors(t *testing.T) {
 	}
 
 	interceptor := &FuncInterceptor{
-		BeforeTaskFn: func(decision *swf.ActivityTask) {
+		BeforeTaskFn: func(decision *ActivityContext) {
 			calledBefore = true
 		},
-		AfterTaskCompleteFn: func(decision *swf.ActivityTask, result interface{}) {
+		AfterTaskCompleteFn: func(decision *ActivityContext, result interface{}) {
 			calledComplete = true
 		},
-		AfterTaskFailedFn: func(decision *swf.ActivityTask, err error) {
+		AfterTaskFailedFn: func(decision *ActivityContext, err error) {
 			calledFail = true
 		},
 	}
@@ -37,14 +37,14 @@ func TestInterceptors(t *testing.T) {
 
 	handler := &ActivityHandler{
 		Activity: "test",
-		HandlerFunc: func(activityTask *swf.ActivityTask, input interface{}) (interface{}, error) {
+		HandlerFunc: func(activityTask *ActivityContext, input interface{}) (interface{}, error) {
 			return nil, nil
 		},
 	}
 
 	worker.AddHandler(handler)
 
-	worker.handleActivityTask(task)
+	worker.handleActivityTask(&ActivityContext{Task: task})
 
 	if !calledBefore {
 		t.Fatal("no before")
@@ -60,7 +60,7 @@ func TestInterceptors(t *testing.T) {
 	calledBefore = false
 	calledComplete = false
 
-	worker.handleActivityTask(task)
+	worker.handleActivityTask(&ActivityContext{Task: task})
 
 	if !calledBefore {
 		t.Fatal("no before")


### PR DESCRIPTION
refactor so that activity machinery takes an ActivityContext everywhere instead of a swf.ActivityTask. 

Provide a Resume(swf.ActivityTask) on the ActivityWorker that allows tasks to be resumed.

This allows all tasks to be resumed. For CoordinatedActivityHandlers, if the task is resumed, Start will not be called, we will just resume calling Tick.

/cc @fabiokung 
