### PR TITLE
Rate limit coordinated workers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 GO_PACKAGES := $(shell go list ./... | sed 's_github.com/sclasen/swfsm_._')
 
 
-all: build
+all: ready test
 
 travis: tidy test
 

--- a/activity/coordinated_worker.go
+++ b/activity/coordinated_worker.go
@@ -15,121 +15,103 @@ const (
 	TaskGone = "Unknown activity"
 )
 
-func (w *ActivityWorker) AddCoordinatedHandler(heartbeatInterval time.Duration, handler *CoordinatedActivityHandler) {
-
-	ticks := make(chan CoordinatedActivityHandlerTick)
-	startErr := make(chan error)
-
-	handlerTickFunc := func(activityTask *swf.ActivityTask, input interface{}) {
-		go func() {
-			cont, res, err := handler.Tick(activityTask, input)
-			ticks <- CoordinatedActivityHandlerTick{
-				Continue: cont,
-				Result:   res,
-				Error:    err,
-			}
-		}()
+// AddCoordinatedHandler automatically takes care of sending back heartbeats and
+// updating state on workflows for an activity task. tickMinInterval determines
+// the max rate at which the CoordinatedActivityHandler.Tick function will be
+// called.
+//
+// For example, when the Tick function returns quickly (e.g.: noop), and
+// tickMinInterval is 1 * time.Second, Tick is guaranteed to be called at most
+// once per second. The rate can be slower if Tick takes more than
+// tickMinInterval to complete.
+func (w *ActivityWorker) AddCoordinatedHandler(heartbeatInterval, tickMinInterval time.Duration, handler *CoordinatedActivityHandler) {
+	adapter := &coordinatedActivityAdapter{
+		heartbeatInterval: heartbeatInterval,
+		tickMinInterval:   tickMinInterval,
+		worker:            w,
+		handler:           handler,
 	}
+	w.AddHandler(&ActivityHandler{
+		Activity:    handler.Activity,
+		HandlerFunc: adapter.coordinate,
+		Input:       handler.Input,
+	})
+}
 
-	handlerStartFunc := func(activityTask *swf.ActivityTask, input interface{}) {
-		go func() {
-			update, err := handler.Start(activityTask, input)
-			if err != nil {
-				startErr <- err
-			} else {
-				err = w.signalStart(activityTask, update)
-				if err != nil {
-					startErr <- err
-				} else {
-					handlerTickFunc(activityTask, input)
-				}
-			}
-		}()
-	}
+type coordinatedActivityAdapter struct {
+	heartbeatInterval time.Duration
+	tickMinInterval   time.Duration
+	worker            *ActivityWorker
+	handler           *CoordinatedActivityHandler
+}
 
-	heartbeats := time.Tick(heartbeatInterval)
-
-	handlerFunc := func(activityTask *swf.ActivityTask, input interface{}) {
-		handlerStartFunc(activityTask, input)
-		for {
-			select {
-			case e := <-startErr:
-				log.Printf("workflow-id=%s activity-id=%s activity-id=%s at=start-error error=%q", LS(activityTask.WorkflowExecution.WorkflowID), LS(activityTask.ActivityType.Name), LS(activityTask.ActivityID), e)
-				w.fail(activityTask, e)
-				return
-			case tick := <-ticks:
-				if tick.Continue {
-					handlerTickFunc(activityTask, input)
-					if tick.Result != nil {
-						//send an activity update when the result is not null, but we are continuing
-						err := w.signalUpdate(activityTask, tick.Result)
-						if err != nil {
-							log.Printf("workflow-id=%s activity-id=%s activity-id=%s at=signal-update-error error=%q", LS(activityTask.WorkflowExecution.WorkflowID), LS(activityTask.ActivityType.Name), LS(activityTask.ActivityID), err)
-							w.fail(activityTask, err)
-							log.Printf("workflow-id=%s activity-id=%s activity-id=%s at=signal-update-error-fail-task error=%q", LS(activityTask.WorkflowExecution.WorkflowID), LS(activityTask.ActivityType.Name), LS(activityTask.ActivityID), err)
-							handler.Cancel(activityTask, tick.Result)
-							log.Printf("workflow-id=%s activity-id=%s activity-id=%s at=signal-update-error-cancel-handler error=%q", LS(activityTask.WorkflowExecution.WorkflowID), LS(activityTask.ActivityType.Name), LS(activityTask.ActivityID), err)
-
-						} else {
-							log.Printf("workflow-id=%s activity-id=%s activity-id=%s at=signal-update", LS(activityTask.WorkflowExecution.WorkflowID), LS(activityTask.ActivityType.Name), LS(activityTask.ActivityID))
-						}
-					}
-				} else {
-					if tick.Error != nil {
-						w.fail(activityTask, tick.Error)
-					} else {
-						w.result(activityTask, tick.Result)
-					}
+func (c *coordinatedActivityAdapter) heartbeat(activityTask *swf.ActivityTask, stop <-chan struct{}, cancelActivity chan error) {
+	heartbeats := time.NewTicker(c.heartbeatInterval)
+	defer heartbeats.Stop()
+	for {
+		select {
+		case <-heartbeats.C:
+			if status, err := c.worker.SWF.RecordActivityTaskHeartbeat(&swf.RecordActivityTaskHeartbeatInput{
+				TaskToken: activityTask.TaskToken,
+			}); err != nil {
+				if ae, ok := err.(aws.APIError); ok && ae.Code == ErrorTypeUnknownResourceFault && strings.Contains(ae.Message, TaskGone) {
+					log.Printf("workflow-id=%s activity-id=%s activity-id=%s at=activity-gone", LS(activityTask.WorkflowExecution.WorkflowID), LS(activityTask.ActivityType.Name), LS(activityTask.ActivityID))
+					cancelActivity <- nil
 					return
 				}
-			case <-heartbeats:
-				status, err := w.SWF.RecordActivityTaskHeartbeat(&swf.RecordActivityTaskHeartbeatInput{
-					TaskToken: activityTask.TaskToken,
-				})
-				if err != nil {
-					if ae, ok := err.(aws.APIError); ok && ae.Code == ErrorTypeUnknownResourceFault && strings.Contains(ae.Message, TaskGone) {
-						log.Printf("workflow-id=%s activity-id=%s activity-id=%s at=activity-gone", LS(activityTask.WorkflowExecution.WorkflowID), LS(activityTask.ActivityType.Name), LS(activityTask.ActivityID))
-						//wait for the tick to complete before exiting
-						<-ticks
-						err := handler.Cancel(activityTask, input)
-						if err != nil {
-							log.Printf("workflow-id=%s activity-id=%s activity-id=%s at=activity-gone-cancel-err err=%q", LS(activityTask.WorkflowExecution.WorkflowID), LS(activityTask.ActivityType.Name), LS(activityTask.ActivityID), err)
-						}
-						return
-					}
-					log.Printf("workflow-id=%s activity-id=%s activity-id=%s at=heartbeat-error error=%s ", LS(activityTask.WorkflowExecution.WorkflowID), LS(activityTask.ActivityType.Name), LS(activityTask.ActivityID), err.Error())
-				} else {
-					log.Printf("workflow-id=%s activity-id=%s activity-id=%s at=heartbeat-recorded", LS(activityTask.WorkflowExecution.WorkflowID), LS(activityTask.ActivityType.Name), LS(activityTask.ActivityID))
-					if *status.CancelRequested {
-						log.Printf("workflow-id=%s activity-id=%s activity-id=%s at=activity-cancel-requested", LS(activityTask.WorkflowExecution.WorkflowID), LS(activityTask.ActivityType.Name), LS(activityTask.ActivityID))
-						//Wait for any tick to finish
-						<-ticks
-						var detail *string
-						err := handler.Cancel(activityTask, input)
-						if err != nil {
-							log.Printf("workflow-id=%s activity-id=%s activity-id=%s at=activity-cancel-err err=%q", LS(activityTask.WorkflowExecution.WorkflowID), LS(activityTask.ActivityType.Name), LS(activityTask.ActivityID), err)
-							detail = S(err.Error())
-						}
-						w.canceled(activityTask, detail)
-						log.Printf("workflow-id=%s activity-id=%s activity-id=%s at=activity-canceled", LS(activityTask.WorkflowExecution.WorkflowID), LS(activityTask.ActivityType.Name), LS(activityTask.ActivityID))
-						return
-					}
+				log.Printf("workflow-id=%s activity-id=%s activity-id=%s at=heartbeat-error error=%s ", LS(activityTask.WorkflowExecution.WorkflowID), LS(activityTask.ActivityType.Name), LS(activityTask.ActivityID), err.Error())
+			} else {
+				log.Printf("workflow-id=%s activity-id=%s activity-id=%s at=heartbeat-recorded", LS(activityTask.WorkflowExecution.WorkflowID), LS(activityTask.ActivityType.Name), LS(activityTask.ActivityID))
+				if *status.CancelRequested {
+					log.Printf("workflow-id=%s activity-id=%s activity-id=%s at=activity-cancel-requested", LS(activityTask.WorkflowExecution.WorkflowID), LS(activityTask.ActivityType.Name), LS(activityTask.ActivityID))
+					cancelActivity <- ActivityTaskCanceledError{}
+					return
 				}
+			}
+		case <-stop:
+			return
+		}
+	}
+}
+
+func (c *coordinatedActivityAdapter) coordinate(activityTask *swf.ActivityTask, input interface{}) (interface{}, error) {
+	update, err := c.handler.Start(activityTask, input)
+	if err != nil {
+		return nil, err
+	}
+	if err := c.worker.signalStart(activityTask, update); err != nil {
+		return nil, err
+	}
+
+	cancel := make(chan error)
+	stopHeartbeating := make(chan struct{})
+
+	go c.heartbeat(activityTask, stopHeartbeating, cancel)
+	defer close(stopHeartbeating)
+
+	ticks := time.NewTicker(c.tickMinInterval)
+	defer ticks.Stop()
+	for {
+		select {
+		case cause := <-cancel:
+			if err := c.handler.Cancel(activityTask, input); err != nil {
+				log.Printf("workflow-id=%s activity-id=%s activity-id=%s at=activity-cancel-err err=%q", LS(activityTask.WorkflowExecution.WorkflowID), LS(activityTask.ActivityType.Name), LS(activityTask.ActivityID), err)
+			}
+			return nil, cause
+		case <-ticks.C:
+			cont, res, err := c.handler.Tick(activityTask, input)
+			if !cont {
+				return res, err
+			}
+			if res != nil {
+				//send an activity update when the result is not null, but we are continuing
+				if err := c.worker.signalUpdate(activityTask, res); err != nil {
+					log.Printf("workflow-id=%s activity-id=%s activity-id=%s at=signal-update-error error=%q", LS(activityTask.WorkflowExecution.WorkflowID), LS(activityTask.ActivityType.Name), LS(activityTask.ActivityID), err)
+					cancel <- err
+					continue // go pick up the cancel message
+				}
+				log.Printf("workflow-id=%s activity-id=%s activity-id=%s at=signal-update", LS(activityTask.WorkflowExecution.WorkflowID), LS(activityTask.ActivityType.Name), LS(activityTask.ActivityID))
 			}
 		}
 	}
-
-	l := &LongRunningActivityHandler{
-		Activity:    handler.Activity,
-		HandlerFunc: handlerFunc,
-		Input:       handler.Input,
-	}
-
-	w.AddLongRunningHandler(l)
-}
-
-type CoordinatedActivityHandlerTick struct {
-	Continue bool
-	Result   interface{}
-	Error    error
 }

--- a/activity/handler.go
+++ b/activity/handler.go
@@ -15,14 +15,6 @@ type ActivityHandler struct {
 	Input       interface{}
 }
 
-type LongRunningActivityHandlerFunc func(activityTask *swf.ActivityTask, input interface{})
-
-type LongRunningActivityHandler struct {
-	Activity    string
-	HandlerFunc LongRunningActivityHandlerFunc
-	Input       interface{}
-}
-
 type CoordinatedActivityHandlerStartFunc func(*swf.ActivityTask, interface{}) (interface{}, error)
 
 type CoordinatedActivityHandlerTickFunc func(*swf.ActivityTask, interface{}) (bool, interface{}, error)
@@ -52,21 +44,6 @@ func NewActivityHandler(activity string, handler interface{}) *ActivityHandler {
 	}
 }
 
-func NewLongRunningActivityHandler(activity string, handler interface{}) *LongRunningActivityHandler {
-	input := inputType(handler, 1)
-	newType := input
-	if input.Kind() == reflect.Ptr {
-		newType = input.Elem()
-	}
-
-	typeCheck(handler, []string{"*swf.ActivityTask", input.String()}, []string{})
-	return &LongRunningActivityHandler{
-		Activity:    activity,
-		HandlerFunc: marshalledFunc{reflect.ValueOf(handler)}.longRunningActivityHandlerFunc,
-		Input:       reflect.New(newType).Elem().Interface(),
-	}
-}
-
 func NewCoordinatedActivityHandler(activity string, start interface{}, tick interface{}, cancel interface{}) *CoordinatedActivityHandler {
 
 	input := inputType(tick, 1)
@@ -91,10 +68,6 @@ func NewCoordinatedActivityHandler(activity string, start interface{}, tick inte
 }
 
 func (a *ActivityHandler) ZeroInput() interface{} {
-	return reflect.New(reflect.TypeOf(a.Input)).Interface()
-}
-
-func (a *LongRunningActivityHandler) ZeroInput() interface{} {
 	return reflect.New(reflect.TypeOf(a.Input)).Interface()
 }
 

--- a/activity/handler_test.go
+++ b/activity/handler_test.go
@@ -3,8 +3,6 @@ package activity
 import (
 	"testing"
 
-	"time"
-
 	"github.com/awslabs/aws-sdk-go/gen/swf"
 )
 
@@ -27,16 +25,6 @@ func TestHandler(t *testing.T) {
 		t.Fatal("string not fooOut")
 	}
 
-	handled := make(chan struct{}, 1)
-	longhandler := NewLongRunningActivityHandler("activity", LongHandler(handled))
-	longhandler.HandlerFunc(&swf.ActivityTask{}, &TestInput{Name: "testIn"})
-	select {
-	case <-handled:
-		t.Log("handled")
-	case <-time.After(25 * time.Millisecond):
-		t.Fatal("not handled")
-	}
-
 	nilHandler := NewActivityHandler("activity", NilHandler)
 	ret, err = nilHandler.HandlerFunc(&swf.ActivityTask{}, &TestInput{Name: "testIn"})
 	if err != nil {
@@ -55,12 +43,6 @@ func Handler(task *swf.ActivityTask, input *TestInput) (*TestOutput, error) {
 
 func NilHandler(task *swf.ActivityTask, input *TestInput) (*TestOutput, error) {
 	return nil, nil
-}
-
-func LongHandler(handled chan struct{}) func(task *swf.ActivityTask, input *TestInput) {
-	return func(task *swf.ActivityTask, input *TestInput) {
-		handled <- struct{}{}
-	}
 }
 
 func StringHandler(task *swf.ActivityTask, input string) (string, error) {

--- a/activity/interceptors.go
+++ b/activity/interceptors.go
@@ -6,16 +6,18 @@ import (
 
 //ActivityInterceptor allows manipulation of the decision task and the outcome at key points in the task lifecycle.
 type ActivityInterceptor interface {
-	BeforeTask(decision *swf.ActivityTask)
-	AfterTaskComplete(decision *swf.ActivityTask, result interface{})
-	AfterTaskFailed(decision *swf.ActivityTask, err error)
+	BeforeTask(*swf.ActivityTask)
+	AfterTaskComplete(t *swf.ActivityTask, result interface{})
+	AfterTaskFailed(t *swf.ActivityTask, err error)
+	AfterTaskCanceled(t *swf.ActivityTask, details string)
 }
 
 //FuncInterceptor is a ActivityInterceptor that you can set handler funcs on. if any are unset, they are no-ops.
 type FuncInterceptor struct {
-	BeforeTaskFn        func(decision *swf.ActivityTask)
-	AfterTaskCompleteFn func(decision *swf.ActivityTask, result interface{})
-	AfterTaskFailedFn   func(decision *swf.ActivityTask, err error)
+	BeforeTaskFn        func(*swf.ActivityTask)
+	AfterTaskCompleteFn func(t *swf.ActivityTask, result interface{})
+	AfterTaskFailedFn   func(t *swf.ActivityTask, err error)
+	AfterTaskCanceledFn func(t *swf.ActivityTask, details string)
 }
 
 //BeforeTask runs the BeforeTaskFn if not nil
@@ -36,5 +38,12 @@ func (i *FuncInterceptor) AfterTaskComplete(activity *swf.ActivityTask, result i
 func (i *FuncInterceptor) AfterTaskFailed(activity *swf.ActivityTask, err error) {
 	if i.AfterTaskFailedFn != nil {
 		i.AfterTaskFailedFn(activity, err)
+	}
+}
+
+//AfterTaskCanceled runs the AfterTaskCanceledFn if not nil
+func (i *FuncInterceptor) AfterTaskCanceled(activity *swf.ActivityTask, details string) {
+	if i.AfterTaskCanceledFn != nil {
+		i.AfterTaskCanceledFn(activity, details)
 	}
 }

--- a/activity/worker.go
+++ b/activity/worker.go
@@ -54,8 +54,7 @@ type ActivityWorker struct {
 	// Client used to make SWF api requests.
 	SWF SWFOps
 	// Type Info for handled activities
-	handlers            map[string]*ActivityHandler
-	longRunningHandlers map[string]*LongRunningActivityHandler
+	handlers map[string]*ActivityHandler
 	// ShutdownManager
 	ShutdownManager *poller.ShutdownManager
 	// ActivityTaskDispatcher
@@ -75,13 +74,6 @@ func (a *ActivityWorker) AddHandler(handler *ActivityHandler) {
 		a.handlers = map[string]*ActivityHandler{}
 	}
 	a.handlers[handler.Activity] = handler
-}
-
-func (a *ActivityWorker) AddLongRunningHandler(handler *LongRunningActivityHandler) {
-	if a.longRunningHandlers == nil {
-		a.longRunningHandlers = map[string]*LongRunningActivityHandler{}
-	}
-	a.longRunningHandlers[handler.Activity] = handler
 }
 
 func (a *ActivityWorker) Init() {
@@ -123,67 +115,44 @@ func (a *ActivityWorker) dispatchTask(activityTask *swf.ActivityTask) {
 func (a *ActivityWorker) handleActivityTask(activityTask *swf.ActivityTask) {
 	a.ActivityInterceptor.BeforeTask(activityTask)
 	handler := a.handlers[*activityTask.ActivityType.Name]
-	longHandler := a.longRunningHandlers[*activityTask.ActivityType.Name]
 
-	if handler != nil {
-		var deserialized interface{}
-		if activityTask.Input != nil {
-			switch handler.Input.(type) {
-			case string:
-				deserialized = *activityTask.Input
-			default:
-				deserialized = handler.ZeroInput()
-				err := a.Serializer.Deserialize(*activityTask.Input, deserialized)
-				if err != nil {
-					a.ActivityInterceptor.AfterTaskFailed(activityTask, err)
-					a.fail(activityTask, errors.Annotate(err, "deserialize"))
-					return
-				}
-			}
-
-		} else {
-			deserialized = nil
-		}
-
-		result, err := handler.HandlerFunc(activityTask, deserialized)
-		if err != nil {
-			if e, ok := err.(ActivityTaskCanceledError); ok {
-				a.ActivityInterceptor.AfterTaskCanceled(activityTask, e.details)
-				a.canceled(activityTask, e.Details())
-			} else {
-				a.ActivityInterceptor.AfterTaskFailed(activityTask, err)
-				a.fail(activityTask, errors.Annotate(err, "handler"))
-			}
-		} else {
-			a.result(activityTask, result)
-		}
-	} else if longHandler != nil {
-		var deserialized interface{}
-		if activityTask.Input != nil {
-			switch longHandler.Input.(type) {
-			case string:
-				deserialized = *activityTask.Input
-			default:
-				deserialized = longHandler.ZeroInput()
-				err := a.Serializer.Deserialize(*activityTask.Input, deserialized)
-				if err != nil {
-					a.ActivityInterceptor.AfterTaskFailed(activityTask, err)
-					a.fail(activityTask, errors.Annotate(err, "deserialize"))
-					return
-				}
-			}
-
-		} else {
-			deserialized = nil
-		}
-
-		longHandler.HandlerFunc(activityTask, deserialized)
-
-	} else {
-		//fail
+	if handler == nil {
 		err := errors.NewErr("no handler for activity: %s", LS(activityTask.ActivityType.Name))
 		a.ActivityInterceptor.AfterTaskFailed(activityTask, &err)
 		a.fail(activityTask, &err)
+		return
+	}
+
+	var deserialized interface{}
+	if activityTask.Input != nil {
+		switch handler.Input.(type) {
+		case string:
+			deserialized = *activityTask.Input
+		default:
+			deserialized = handler.ZeroInput()
+			err := a.Serializer.Deserialize(*activityTask.Input, deserialized)
+			if err != nil {
+				a.ActivityInterceptor.AfterTaskFailed(activityTask, err)
+				a.fail(activityTask, errors.Annotate(err, "deserialize"))
+				return
+			}
+		}
+
+	} else {
+		deserialized = nil
+	}
+
+	result, err := handler.HandlerFunc(activityTask, deserialized)
+	if err != nil {
+		if e, ok := err.(ActivityTaskCanceledError); ok {
+			a.ActivityInterceptor.AfterTaskCanceled(activityTask, e.details)
+			a.canceled(activityTask, e.Details())
+		} else {
+			a.ActivityInterceptor.AfterTaskFailed(activityTask, err)
+			a.fail(activityTask, errors.Annotate(err, "handler"))
+		}
+	} else {
+		a.result(activityTask, result)
 	}
 }
 

--- a/activity/worker_test.go
+++ b/activity/worker_test.go
@@ -16,12 +16,13 @@ import (
 )
 
 type MockSWF struct {
-	Activity     *swf.ActivityTask
-	Failed       bool
-	Completed    *string
-	CompletedSet bool
-	History      *swf.History
-	Canceled     bool
+	Activity        *swf.ActivityTask
+	Failed          bool
+	Completed       *string
+	CompletedSet    bool
+	History         *swf.History
+	Canceled        bool
+	CancelResponded bool
 }
 
 func (m *MockSWF) RecordActivityTaskHeartbeat(req *swf.RecordActivityTaskHeartbeatInput) (resp *swf.ActivityTaskStatus, err error) {
@@ -29,7 +30,8 @@ func (m *MockSWF) RecordActivityTaskHeartbeat(req *swf.RecordActivityTaskHeartbe
 		CancelRequested: &m.Canceled,
 	}, nil
 }
-func (*MockSWF) RespondActivityTaskCanceled(req *swf.RespondActivityTaskCanceledInput) (err error) {
+func (m *MockSWF) RespondActivityTaskCanceled(req *swf.RespondActivityTaskCanceledInput) (err error) {
+	m.CancelResponded = true
 	return nil
 }
 func (m *MockSWF) RespondActivityTaskCompleted(req *swf.RespondActivityTaskCompletedInput) (err error) {


### PR DESCRIPTION
... and implement them as a regular `ActivityTaskHandler` so we can get rid of the special case (`LongRunningActivityTaskHandler`).

* Interceptors now work for `CoordinatedActivityTaskHandlers` too.
* `Tick()` is not immediately called after `Start()`, only after `tickMinInterval`.
* support for responding to cancel requests from `ActivyTaskHandlers`.
* `LongRunningActivityTaskHandler` goes away.

I flipped the logic on some if-else chains to reduce nesting and make them simpler, so it may be a bit difficult to read diffs, sorry! It was mostly:

```go
// from
func work() {
	if something {
		// happy path
	} else {
		// sad path
	}
}

// to
func work() {
	if !something {
		// sad path
		return
	}
	// happy path
}
```

/cc @sclasen