### PR TITLE
TestFailOnceActivityInterceptor

### DIFF
--- a/activity/interceptors.go
+++ b/activity/interceptors.go
@@ -7,6 +7,7 @@ import (
 //ActivityInterceptor allows manipulation of the decision task and the outcome at key points in the task lifecycle.
 type ActivityInterceptor interface {
 	BeforeTask(*swf.PollForActivityTaskOutput)
+	AfterTask(t *swf.PollForActivityTaskOutput, result interface{}, err error) (interface{}, error)
 	AfterTaskComplete(t *swf.PollForActivityTaskOutput, result interface{})
 	AfterTaskFailed(t *swf.PollForActivityTaskOutput, err error)
 	AfterTaskCanceled(t *swf.PollForActivityTaskOutput, details string)
@@ -15,6 +16,7 @@ type ActivityInterceptor interface {
 //FuncInterceptor is a ActivityInterceptor that you can set handler funcs on. if any are unset, they are no-ops.
 type FuncInterceptor struct {
 	BeforeTaskFn        func(*swf.PollForActivityTaskOutput)
+	AfterTaskFn         func(t *swf.PollForActivityTaskOutput, result interface{}, err error) (interface{}, error)
 	AfterTaskCompleteFn func(t *swf.PollForActivityTaskOutput, result interface{})
 	AfterTaskFailedFn   func(t *swf.PollForActivityTaskOutput, err error)
 	AfterTaskCanceledFn func(t *swf.PollForActivityTaskOutput, details string)
@@ -25,6 +27,13 @@ func (i *FuncInterceptor) BeforeTask(activity *swf.PollForActivityTaskOutput) {
 	if i.BeforeTaskFn != nil {
 		i.BeforeTaskFn(activity)
 	}
+}
+
+func (i *FuncInterceptor) AfterTask(activity *swf.PollForActivityTaskOutput, result interface{}, err error) (interface{}, error) {
+	if i.AfterTaskFn != nil {
+		return i.AfterTaskFn(activity, result, err)
+	}
+	return result, err
 }
 
 //AfterTaskComplete runs the AfterTaskCompleteFn if not nil


### PR DESCRIPTION
This adds a new `ActivityInterceptor` that fails activities once and then lets them passthrough on the second try. This is enable by default for the `TestListener` to ensure activities have retry handlers. This can be disabled by setting the `NoOpActivityInterceptor` one a worker or for the default in test config.