### PR TITLE
TestFailOnceActivityInterceptor - available but disabled by default.

### DIFF
--- a/activity/interceptors.go
+++ b/activity/interceptors.go
@@ -7,6 +7,7 @@ import (
 //ActivityInterceptor allows manipulation of the decision task and the outcome at key points in the task lifecycle.
 type ActivityInterceptor interface {
 	BeforeTask(*swf.PollForActivityTaskOutput)
+	AfterTask(t *swf.PollForActivityTaskOutput, result interface{}, err error) (interface{}, error)
 	AfterTaskComplete(t *swf.PollForActivityTaskOutput, result interface{})
 	AfterTaskFailed(t *swf.PollForActivityTaskOutput, err error)
 	AfterTaskCanceled(t *swf.PollForActivityTaskOutput, details string)
@@ -15,6 +16,7 @@ type ActivityInterceptor interface {
 //FuncInterceptor is a ActivityInterceptor that you can set handler funcs on. if any are unset, they are no-ops.
 type FuncInterceptor struct {
 	BeforeTaskFn        func(*swf.PollForActivityTaskOutput)
+	AfterTaskFn         func(t *swf.PollForActivityTaskOutput, result interface{}, err error) (interface{}, error)
 	AfterTaskCompleteFn func(t *swf.PollForActivityTaskOutput, result interface{})
 	AfterTaskFailedFn   func(t *swf.PollForActivityTaskOutput, err error)
 	AfterTaskCanceledFn func(t *swf.PollForActivityTaskOutput, details string)
@@ -25,6 +27,13 @@ func (i *FuncInterceptor) BeforeTask(activity *swf.PollForActivityTaskOutput) {
 	if i.BeforeTaskFn != nil {
 		i.BeforeTaskFn(activity)
 	}
+}
+
+func (i *FuncInterceptor) AfterTask(activity *swf.PollForActivityTaskOutput, result interface{}, err error) (interface{}, error) {
+	if i.AfterTaskFn != nil {
+		return i.AfterTaskFn(activity, result, err)
+	}
+	return result, err
 }
 
 //AfterTaskComplete runs the AfterTaskCompleteFn if not nil

--- a/poller/poller.go
+++ b/poller/poller.go
@@ -68,17 +68,17 @@ func (p *DecisionTaskPoller) PollUntilShutdownBy(mgr *ShutdownManager, pollerNam
 	for {
 		select {
 		case <-stop:
-			log.Printf("component=DecisionTaskPoller fn=PollUntilShutdownBy at=recieved-stop action=shutting-down poller=%s", pollerName)
+			log.Printf("component=DecisionTaskPoller fn=PollUntilShutdownBy at=recieved-stop action=shutting-down poller=%s task-list=%q", pollerName, p.TaskList)
 			stopAck <- true
 			return
 		default:
 			task, err := p.Poll()
 			if err != nil {
-				log.Printf("component=DecisionTaskPoller fn=PollUntilShutdownBy at=poll-err  poller=%s error=%q", pollerName, err)
+				log.Printf("component=DecisionTaskPoller fn=PollUntilShutdownBy at=poll-err poller=%s task-list=%q error=%q", pollerName, p.TaskList, err)
 				continue
 			}
 			if task == nil {
-				log.Printf("component=DecisionTaskPoller fn=PollUntilShutdownBy at=poll-no-task  poller=%s", pollerName)
+				log.Printf("component=DecisionTaskPoller fn=PollUntilShutdownBy at=poll-no-task poller=%s task-list=%q", pollerName, p.TaskList)
 				continue
 			}
 			onTask(task)
@@ -142,17 +142,17 @@ func (p *ActivityTaskPoller) PollUntilShutdownBy(mgr *ShutdownManager, pollerNam
 	for {
 		select {
 		case <-stop:
-			log.Printf("component=ActivityTaskPoller fn=PollUntilShutdownBy at=recieved-stop action=shutting-down poller=%s", pollerName)
+			log.Printf("component=ActivityTaskPoller fn=PollUntilShutdownBy at=recieved-stop action=shutting-down poller=%s task-list=%q", pollerName, p.TaskList)
 			stopAck <- true
 			return
 		default:
 			task, err := p.Poll()
 			if err != nil {
-				log.Printf("component=ActivityTaskPoller fn=PollUntilShutdownBy at=poll-err  poller=%s error=%q", pollerName, err)
+				log.Printf("component=ActivityTaskPoller fn=PollUntilShutdownBy at=poll-err poller=%s task-list=%q error=%q", pollerName, p.TaskList, err)
 				continue
 			}
 			if task == nil {
-				log.Printf("component=ActivityTaskPoller fn=PollUntilShutdownBy at=poll-no-task  poller=%s", pollerName)
+				log.Printf("component=ActivityTaskPoller fn=PollUntilShutdownBy at=poll-no-task poller=%s task-list=%q", pollerName, p.TaskList)
 				continue
 			}
 			onTask(task)

--- a/testing/listener.go
+++ b/testing/listener.go
@@ -39,10 +39,6 @@ func NewTestListener(t TestConfig) *TestListener {
 		t.DefaultWaitTimeout = 10
 	}
 
-	if t.DefaultActivityInterceptor == nil {
-		t.DefaultActivityInterceptor = TestFailOnceActivityInterceptor()
-	}
-
 	tl := &TestListener{
 		decisionOutcomes: make(chan DecisionOutcome, 1000),
 		historyInterest:  make(map[string]chan *swf.HistoryEvent, 1000),


### PR DESCRIPTION
I have been running into many problems with https://github.com/sclasen/swfsm/pull/57; however, it does not appear to be because of this change directly, but rather the extra time this change introduces to tests.  Because there is still utility in this interceptor (and other logging introduced during debugging), I am going to pull this in as is, but disabled by default.