### PR TITLE
use a client with 2 second timeout when sending heartbeats

### DIFF
--- a/fsm/client.go
+++ b/fsm/client.go
@@ -261,6 +261,9 @@ func (c *client) Start(startTemplate swf.StartWorkflowExecutionInput, id string,
 	startTemplate.Domain = S(c.f.Domain)
 	startTemplate.WorkflowID = S(id)
 	startTemplate.Input = serializedInput
+	if len(startTemplate.TagList) == 0 {
+		startTemplate.TagList = GetTagsIfTaggable(input)
+	}
 	return c.c.StartWorkflowExecution(&startTemplate)
 }
 

--- a/fsm/fsm_test.go
+++ b/fsm/fsm_test.go
@@ -196,10 +196,9 @@ type TestData struct {
 	States []string
 }
 
-func (t *TestData) Tags()[]*string{
+func (t *TestData) Tags() []*string {
 	return []*string{S("tag1"), S("tag2")}
 }
-
 
 func TestMarshalledDecider(t *testing.T) {
 	typedDecider := func(f *FSMContext, h *swf.HistoryEvent, d *TestData) Outcome {
@@ -502,10 +501,9 @@ func TestContinueWorkflowDecision(t *testing.T) {
 	}
 
 	tags := cont.ContinueAsNewWorkflowExecutionDecisionAttributes.TagList
-	if len(tags) != 2 || *tags[0] != "tag1"  || *tags[1] != "tag2" {
+	if len(tags) != 2 || *tags[0] != "tag1" || *tags[1] != "tag2" {
 		t.Fatal(testData, cont)
 	}
-
 
 }
 
@@ -584,4 +582,3 @@ func testHistoryEvent(eventID int, eventType string) *swf.HistoryEvent {
 
 var testWorkflowExecution = &swf.WorkflowExecution{WorkflowID: S("workflow-id"), RunID: S("run-id")}
 var testWorkflowType = &swf.WorkflowType{Name: S("workflow-name"), Version: S("workflow-version")}
-

--- a/fsm/fsm_test.go
+++ b/fsm/fsm_test.go
@@ -196,6 +196,11 @@ type TestData struct {
 	States []string
 }
 
+func (t *TestData) Tags()[]*string{
+	return []*string{S("tag1"), S("tag2")}
+}
+
+
 func TestMarshalledDecider(t *testing.T) {
 	typedDecider := func(f *FSMContext, h *swf.HistoryEvent, d *TestData) Outcome {
 		if d.States[0] != "marshalled" {
@@ -496,6 +501,12 @@ func TestContinueWorkflowDecision(t *testing.T) {
 		t.Fatal(testData, cont)
 	}
 
+	tags := cont.ContinueAsNewWorkflowExecutionDecisionAttributes.TagList
+	if len(tags) != 2 || *tags[0] != "tag1"  || *tags[1] != "tag2" {
+		t.Fatal(testData, cont)
+	}
+
+
 }
 
 func TestCompleteState(t *testing.T) {
@@ -573,3 +584,4 @@ func testHistoryEvent(eventID int, eventType string) *swf.HistoryEvent {
 
 var testWorkflowExecution = &swf.WorkflowExecution{WorkflowID: S("workflow-id"), RunID: S("run-id")}
 var testWorkflowType = &swf.WorkflowType{Name: S("workflow-name"), Version: S("workflow-version")}
+

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -8,9 +8,10 @@ import (
 	"regexp"
 	"strconv"
 
+	"log"
+
 	"github.com/awslabs/aws-sdk-go/aws"
 	"github.com/awslabs/aws-sdk-go/internal/apierr"
-	"log"
 )
 
 //copy of aws.SendHandler modified to use different http clients for timeouts
@@ -26,13 +27,13 @@ func SWFSendHandler(polling, heartbeat *http.Client) func(*aws.Request) {
 		if r.Service.ServiceName == "swf" {
 			switch r.Operation.Name {
 			case "PollForDecisionTask", "PollForActivityTash":
-				log.Printf("using polling client")
+				log.Printf("using polling client %s %s", r.Service.ServiceName, r.Operation.Name)
 				client = polling
 			case "RecordActivityTaskHeartbeat":
-				log.Printf("using heartbeat client")
+				log.Printf("using heartbeat client %s %s", r.Service.ServiceName, r.Operation.Name)
 				client = heartbeat
 			default:
-				log.Printf("using std client")
+				log.Printf("using std client %s %s", r.Service.ServiceName, r.Operation.Name)
 			}
 
 		}

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -26,7 +26,7 @@ func SWFSendHandler(polling, heartbeat *http.Client) func(*aws.Request) {
 		client := r.Service.Config.HTTPClient
 		if r.Service.ServiceName == "swf" {
 			switch r.Operation.Name {
-			case "PollForDecisionTask", "PollForActivityTash":
+			case "PollForDecisionTask", "PollForActivityTask":
 				log.Printf("using polling client %s %s", r.Service.ServiceName, r.Operation.Name)
 				client = polling
 			case "RecordActivityTaskHeartbeat":

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/awslabs/aws-sdk-go/aws"
 	"github.com/awslabs/aws-sdk-go/internal/apierr"
+	"log"
 )
 
 //copy of aws.SendHandler modified to use different http clients for timeouts
@@ -25,10 +26,15 @@ func SWFSendHandler(polling, heartbeat *http.Client) func(*aws.Request) {
 		if r.Service.ServiceName == "swf" {
 			switch r.Operation.Name {
 			case "PollForDecisionTask", "PollForActivityTash":
+				log.Printf("using polling client")
 				client = polling
 			case "RecordActivityTaskHeartbeat":
+				log.Printf("using heartbeat client")
 				client = heartbeat
+			default:
+				log.Printf("using std client")
 			}
+
 		}
 		var err error
 		r.HTTPResponse, err = client.Do(r.HTTPRequest)

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -1,0 +1,55 @@
+package handler
+
+import (
+	"bytes"
+	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/internal/apierr"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strconv"
+)
+
+//copy of aws.SendHandler modified to use different http clients for timeouts
+//on polling and heartbeating.
+//to use, when constructing an swf.SWM
+// swfClient.Service.Handlers.Send.Clear()
+// swfClient.Service.Handlers.Send.PushBack(handler.SWFSendHandler(polling, heartbeat))
+func SWFSendHandler(polling, heartbeat *http.Client) func(*aws.Request) {
+	var reStatusCode = regexp.MustCompile(`^(\d+)`)
+
+	return func(r *aws.Request) {
+		client := r.Service.Config.HTTPClient
+		if r.Service.ServiceName == "swf" {
+			switch r.Operation.Name {
+			case "PollForDecisionTask", "PollForActivityTash":
+				client = polling
+			case "RecordActivityTaskHeartbeat":
+				client = heartbeat
+			}
+		}
+		var err error
+		r.HTTPResponse, err = client.Do(r.HTTPRequest)
+		if err != nil {
+			// Capture the case where url.Error is returned for error processing
+			// response. e.g. 301 without location header comes back as string
+			// error and r.HTTPResponse is nil. Other url redirect errors will
+			// comeback in a similar method.
+			if e, ok := err.(*url.Error); ok {
+				if s := reStatusCode.FindStringSubmatch(e.Error()); s != nil {
+					code, _ := strconv.ParseInt(s[1], 10, 64)
+					r.HTTPResponse = &http.Response{
+						StatusCode: int(code),
+						Status:     http.StatusText(int(code)),
+						Body:       ioutil.NopCloser(bytes.NewReader([]byte{})),
+					}
+					return
+				}
+			}
+			// Catch all other request errors.
+			r.Error = apierr.New("RequestError", "send request failed", err)
+			r.Retryable.Set(true) // network errors are retryable
+		}
+	}
+}

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -27,13 +27,19 @@ func SWFSendHandler(polling, heartbeat *http.Client) func(*aws.Request) {
 		if r.Service.ServiceName == "swf" {
 			switch r.Operation.Name {
 			case "PollForDecisionTask", "PollForActivityTask":
-				log.Printf("using polling client %s %s", r.Service.ServiceName, r.Operation.Name)
+				if r.Service.Config.LogLevel > 0 {
+					log.Printf("using polling client %s %s", r.Service.ServiceName, r.Operation.Name)
+				}
 				client = polling
 			case "RecordActivityTaskHeartbeat":
-				log.Printf("using heartbeat client %s %s", r.Service.ServiceName, r.Operation.Name)
+				if r.Service.Config.LogLevel > 0 {
+					log.Printf("using heartbeat client %s %s", r.Service.ServiceName, r.Operation.Name)
+				}
 				client = heartbeat
 			default:
-				log.Printf("using std client %s %s", r.Service.ServiceName, r.Operation.Name)
+				if r.Service.Config.LogLevel > 0 {
+					log.Printf("using std client %s %s", r.Service.ServiceName, r.Operation.Name)
+				}
 			}
 
 		}

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -2,13 +2,14 @@ package handler
 
 import (
 	"bytes"
-	"github.com/awslabs/aws-sdk-go/aws"
-	"github.com/awslabs/aws-sdk-go/internal/apierr"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"regexp"
 	"strconv"
+
+	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/internal/apierr"
 )
 
 //copy of aws.SendHandler modified to use different http clients for timeouts


### PR DESCRIPTION
/cc @dpiddy @fabiokung this may help (or not) with the heartbeat timeouts we have been seeing where latencies get high enough for the heartbeat timeout to get reached.

here we use an httpclient that has a 2 second timeout, only for sending heartbeats.