### PR TITLE
back to StartFSMWorkflowInput, 

### DIFF
--- a/fsm/client.go
+++ b/fsm/client.go
@@ -256,11 +256,7 @@ func (c *client) Signal(id string, signal string, input interface{}) error {
 func (c *client) Start(startTemplate swf.StartWorkflowExecutionInput, id string, input interface{}) (*swf.StartWorkflowExecutionOutput, error) {
 	var serializedInput *string
 	if input != nil {
-		ser, err := c.f.Serializer.Serialize(input)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		serializedInput = S(ser)
+		serializedInput = StartFSMWorkflowInput(c.f, input)
 	}
 	startTemplate.Domain = S(c.f.Domain)
 	startTemplate.WorkflowID = S(id)

--- a/fsm/correlator_test.go
+++ b/fsm/correlator_test.go
@@ -112,7 +112,7 @@ func TestTrackPendingActivities(t *testing.T) {
 			EventID:   I(1),
 			EventType: S("WorkflowExecutionStarted"),
 			WorkflowExecutionStartedEventAttributes: &swf.WorkflowExecutionStartedEventAttributes{
-				Input: S(fsm.Serialize(new(TestData))),
+				Input: StartFSMWorkflowInput(fsm, new(TestData)),
 			},
 		},
 	}

--- a/fsm/fsm.go
+++ b/fsm/fsm.go
@@ -602,21 +602,14 @@ func (f *FSM) statefulHistoryEventToSerializedState(event *swf.HistoryEvent) (*S
 		return state, err
 	} else if *event.EventType == swf.EventTypeWorkflowExecutionStarted {
 		state := &SerializedState{}
-		//If the workflow is continued, we expect a full SerializedState as Input
-		if event.WorkflowExecutionStartedEventAttributes.ContinuedExecutionRunID != nil {
-			err := f.Serializer.Deserialize(*event.WorkflowExecutionStartedEventAttributes.Input, state)
-			if err == nil {
-				if state.StateName == "" {
-					state.StateName = f.initialState.Name
-				}
+		err := f.Serializer.Deserialize(*event.WorkflowExecutionStartedEventAttributes.Input, state)
+		if err == nil {
+			if state.StateName == "" {
+				state.StateName = f.initialState.Name
 			}
-			return state, err
 		}
-		//Otherwise we expect just a stateData struct
-		state.StateVersion = 0
-		state.StateName = f.initialState.Name
-		state.StateData = *event.WorkflowExecutionStartedEventAttributes.Input
-		return state, nil
+		return state, err
+
 	}
 	return nil, nil
 }

--- a/fsm/fsm_models.go
+++ b/fsm/fsm_models.go
@@ -404,3 +404,13 @@ type FSMSnapshotEvent struct {
 	Input   interface{}
 	Output  interface{}
 }
+
+// StartFSMWorkflowInput should be used to construct the input for any StartWorkflowExecutionRequests.
+// This panics on errors cause really this should never err.
+func StartFSMWorkflowInput(serializer Serialization, data interface{}) *string {
+	ss := new(SerializedState)
+	stateData := serializer.Serialize(data)
+	ss.StateData = stateData
+	serialized := serializer.Serialize(ss)
+	return aws.String(serialized)
+}

--- a/fsm/fsm_models.go
+++ b/fsm/fsm_models.go
@@ -178,6 +178,14 @@ func NewFSMContext(
 	}
 }
 
+func (f *FSMContext) InitialState() string {
+	return f.serialization.InitialState()
+}
+
+func (f *FSMContext) StateSerializer() StateSerializer {
+	return f.serialization.StateSerializer()
+}
+
 // ContinueDecider is a helper func to easily create a ContinueOutcome.
 func (f *FSMContext) ContinueDecider(data interface{}, decisions []*swf.Decision) Outcome {
 	return Outcome{

--- a/fsm/fsm_test.go
+++ b/fsm/fsm_test.go
@@ -532,6 +532,15 @@ func TestCompleteState(t *testing.T) {
 	}
 }
 
+func TestSerializationInterface(t *testing.T) {
+	f := func(s Serialization) {
+
+	}
+
+	f(&FSM{})
+	f(&FSMContext{})
+}
+
 func testFSM() *FSM {
 	fsm := &FSM{
 		Name:             "test-fsm",

--- a/fsm/fsm_test.go
+++ b/fsm/fsm_test.go
@@ -79,7 +79,7 @@ func TestFSM(t *testing.T) {
 		&swf.HistoryEvent{EventType: S("DecisionTaskStarted"), EventID: I(3)},
 		&swf.HistoryEvent{EventType: S("DecisionTaskScheduled"), EventID: I(2)},
 		EventFromPayload(1, &swf.WorkflowExecutionStartedEventAttributes{
-			Input: S(fsm.Serialize(new(TestData))),
+			Input: StartFSMWorkflowInput(fsm, new(TestData)),
 		}),
 	}
 
@@ -515,7 +515,7 @@ func TestCompleteState(t *testing.T) {
 		EventID:   I(1),
 		EventType: S("WorkflowExecutionStarted"),
 		WorkflowExecutionStartedEventAttributes: &swf.WorkflowExecutionStartedEventAttributes{
-			Input: S(fsm.Serialize(new(TestData))),
+			Input: StartFSMWorkflowInput(fsm, new(TestData)),
 		},
 	}
 

--- a/fsm/interceptors_test.go
+++ b/fsm/interceptors_test.go
@@ -57,7 +57,7 @@ func TestInterceptors(t *testing.T) {
 			EventID:   I(10),
 			EventType: S("WorkflowExecutionStarted"),
 			WorkflowExecutionStartedEventAttributes: &swf.WorkflowExecutionStartedEventAttributes{
-				Input: S(fsm.Serialize(new(TestData))),
+				Input: StartFSMWorkflowInput(fsm, new(TestData)),
 			},
 		},
 	}

--- a/fsm/replicators_test.go
+++ b/fsm/replicators_test.go
@@ -68,7 +68,7 @@ func TestKinesisReplication(t *testing.T) {
 			EventID:   I(1),
 			EventType: S("WorkflowExecutionStarted"),
 			WorkflowExecutionStartedEventAttributes: &swf.WorkflowExecutionStartedEventAttributes{
-				Input: S(fsm.Serialize(new(TestData))),
+				Input: StartFSMWorkflowInput(fsm, new(TestData)),
 			},
 		},
 	}


### PR DESCRIPTION
so we can restart failed workflows from console/cli/programatically, and not lose stateVersion stateName, etc.


/cc @fabiokung :( 