### PR TITLE
Generic Snapshots

### DIFF
--- a/fsm/client.go
+++ b/fsm/client.go
@@ -341,18 +341,8 @@ func (c *client) snapshotsFromHistoryEventIterator(next func() *swf.HistoryEvent
 	var err error
 
 	refs := make(map[int64][]int64)
-
-	snapshot := FSMSnapshot{
-		State: &FSMSnapshotState{
-			Name:    "<unrecorded>",
-			ID:      999999,
-			Version: 999999,
-		},
-		Events: []*FSMSnapshotEvent{},
-	}
-
+	snapshot := FSMSnapshot{Events: []*FSMSnapshotEvent{}}
 	var nextCorrelator *EventCorrelator
-
 	for event := next(); event != nil; event = next() {
 		if c.f.isCorrelatorMarker(event) {
 			correlator, err := c.f.findSerializedEventCorrelator([]*swf.HistoryEvent{event})
@@ -390,6 +380,14 @@ func (c *client) snapshotsFromHistoryEventIterator(next func() *swf.HistoryEvent
 			nextCorrelator = nil
 
 			continue
+		}
+
+		if snapshot.State == nil {
+			snapshot.State = &FSMSnapshotState{
+				Name:    "<unrecorded>",
+				ID:      999999,
+				Version: 999999,
+			}
 		}
 
 		eventAttributes, err := c.snapshotEventAttributesMap(event)

--- a/fsm/client.go
+++ b/fsm/client.go
@@ -395,9 +395,9 @@ func (c *client) snapshotsFromHistoryEventIterator(next func() *swf.HistoryEvent
 			break
 		}
 
-		for _, refKey := range []string{"ScheduledEventID", "StartedEventID"} {
-			if raw, ok := eventAttributes[refKey]; ok {
-				parsed, err := strconv.ParseInt(fmt.Sprint(raw), 10, 64)
+		for key, value := range eventAttributes {
+			if strings.HasSuffix(key, "EventID") {
+				parsed, err := strconv.ParseInt(fmt.Sprint(value), 10, 64)
 				if err != nil {
 					break
 				}

--- a/fsm/client.go
+++ b/fsm/client.go
@@ -9,6 +9,9 @@ import (
 	"io"
 	"strings"
 
+	"encoding/json"
+	"reflect"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/swf"
@@ -335,222 +338,25 @@ func (c *client) snapshotsFromHistoryEventIterator(next func() *swf.HistoryEvent
 	snapshots := []FSMSnapshot{}
 	var err error
 
-	snapshot := FSMSnapshot{}
+	snapshot := FSMSnapshot{
+		State: &FSMSnapshotState{
+			Name:    "<unrecorded>",
+			ID:      999999,
+			Version: 999999,
+		},
+		Events: []*FSMSnapshotEvent{},
+	}
+
+	var nextCorrelator *EventCorrelator
+
 	for event := next(); event != nil; event = next() {
-
-		switch EventType := *event.EventType; EventType {
-
-		// starting
-		case swf.EventTypeWorkflowExecutionStarted:
-			snapshot.Event = &FSMSnapshotEvent{
-				Type:  EventType,
-				Name:  "start",
-				Input: c.tryDeserialize(event.WorkflowExecutionStartedEventAttributes.Input),
+		if c.f.isCorrelatorMarker(event) {
+			correlator, err := c.f.findSerializedEventCorrelator([]*swf.HistoryEvent{event})
+			if err != nil {
+				break
 			}
-
-		// signals
-		case swf.EventTypeWorkflowExecutionSignaled:
-			snapshot.Event = &FSMSnapshotEvent{
-				Type:   EventType,
-				Name:   *event.WorkflowExecutionSignaledEventAttributes.SignalName,
-				Source: *event.WorkflowExecutionSignaledEventAttributes.ExternalWorkflowExecution.WorkflowID,
-				Input:  c.tryDeserialize(event.WorkflowExecutionSignaledEventAttributes.Input),
-			}
-
-		// activities
-		case swf.EventTypeActivityTaskScheduled:
-			if snapshot.Event != nil && snapshot.Event.Input == c.pointerScheduledEventID(event.EventID) {
-				snapshot.Event.Name = *event.ActivityTaskScheduledEventAttributes.ActivityType.Name
-				snapshot.Event.Version = *event.ActivityTaskScheduledEventAttributes.ActivityType.Version
-				snapshot.Event.Input = c.tryDeserialize(event.ActivityTaskScheduledEventAttributes.Input)
-			}
-		case swf.EventTypeScheduleActivityTaskFailed:
-			snapshot.Event = &FSMSnapshotEvent{
-				Type:    EventType,
-				Name:    *event.ScheduleActivityTaskFailedEventAttributes.ActivityType.Name,
-				Version: *event.ScheduleActivityTaskFailedEventAttributes.ActivityType.Version,
-				Target:  *event.ScheduleActivityTaskFailedEventAttributes.ActivityID,
-				Output:  *event.ScheduleActivityTaskFailedEventAttributes.Cause,
-			}
-		case swf.EventTypeActivityTaskCompleted:
-			snapshot.Event = &FSMSnapshotEvent{
-				Type:   EventType,
-				Input:  c.pointerScheduledEventID(event.ActivityTaskCompletedEventAttributes.ScheduledEventID),
-				Output: c.tryDeserialize(event.ActivityTaskCompletedEventAttributes.Result),
-			}
-		case swf.EventTypeActivityTaskFailed:
-			snapshot.Event = &FSMSnapshotEvent{
-				Type:   EventType,
-				Input:  c.pointerScheduledEventID(event.ActivityTaskFailedEventAttributes.ScheduledEventID),
-				Output: c.tryDeserialize(event.ActivityTaskFailedEventAttributes.Details),
-			}
-		case swf.EventTypeActivityTaskCanceled:
-			snapshot.Event = &FSMSnapshotEvent{
-				Type:   EventType,
-				Input:  c.pointerScheduledEventID(event.ActivityTaskCanceledEventAttributes.ScheduledEventID),
-				Output: c.tryDeserialize(event.ActivityTaskCanceledEventAttributes.Details),
-			}
-		case swf.EventTypeActivityTaskTimedOut:
-			snapshot.Event = &FSMSnapshotEvent{
-				Type:   EventType,
-				Input:  c.pointerScheduledEventID(event.ActivityTaskTimedOutEventAttributes.ScheduledEventID),
-				Output: c.tryDeserialize(event.ActivityTaskTimedOutEventAttributes.Details),
-			}
-
-		// children
-		case swf.EventTypeStartChildWorkflowExecutionInitiated:
-			snapshot.Event = &FSMSnapshotEvent{
-				Type:    EventType,
-				Name:    *event.StartChildWorkflowExecutionInitiatedEventAttributes.WorkflowType.Name,
-				Version: *event.StartChildWorkflowExecutionInitiatedEventAttributes.WorkflowType.Version,
-				Input:   c.tryDeserialize(event.StartChildWorkflowExecutionInitiatedEventAttributes.Input),
-				Target:  *event.StartChildWorkflowExecutionInitiatedEventAttributes.WorkflowID,
-			}
-		case swf.EventTypeStartChildWorkflowExecutionFailed:
-			snapshot.Event = &FSMSnapshotEvent{
-				Type:    EventType,
-				Name:    *event.StartChildWorkflowExecutionFailedEventAttributes.WorkflowType.Name,
-				Version: *event.StartChildWorkflowExecutionFailedEventAttributes.WorkflowType.Version,
-				Target:  *event.StartChildWorkflowExecutionFailedEventAttributes.WorkflowID,
-				Output:  *event.StartChildWorkflowExecutionFailedEventAttributes.Cause,
-			}
-		case swf.EventTypeChildWorkflowExecutionFailed:
-			snapshot.Event = &FSMSnapshotEvent{
-				Type:    EventType,
-				Name:    *event.ChildWorkflowExecutionFailedEventAttributes.WorkflowType.Name,
-				Version: *event.ChildWorkflowExecutionFailedEventAttributes.WorkflowType.Version,
-				Target:  *event.ChildWorkflowExecutionFailedEventAttributes.WorkflowExecution.WorkflowID,
-			}
-		case swf.EventTypeChildWorkflowExecutionTimedOut:
-			snapshot.Event = &FSMSnapshotEvent{
-				Type:    EventType,
-				Name:    *event.ChildWorkflowExecutionTimedOutEventAttributes.WorkflowType.Name,
-				Version: *event.ChildWorkflowExecutionTimedOutEventAttributes.WorkflowType.Version,
-				Output:  *event.ChildWorkflowExecutionTimedOutEventAttributes.TimeoutType,
-				Target:  *event.ChildWorkflowExecutionTimedOutEventAttributes.WorkflowExecution.WorkflowID,
-			}
-		case swf.EventTypeChildWorkflowExecutionCanceled:
-			snapshot.Event = &FSMSnapshotEvent{
-				Type:    EventType,
-				Name:    *event.ChildWorkflowExecutionCanceledEventAttributes.WorkflowType.Name,
-				Version: *event.ChildWorkflowExecutionCanceledEventAttributes.WorkflowType.Version,
-				Output:  *event.ChildWorkflowExecutionCanceledEventAttributes.Details,
-				Target:  *event.ChildWorkflowExecutionCanceledEventAttributes.WorkflowExecution.WorkflowID,
-			}
-		case swf.EventTypeChildWorkflowExecutionTerminated:
-			snapshot.Event = &FSMSnapshotEvent{
-				Type:    EventType,
-				Name:    *event.ChildWorkflowExecutionTerminatedEventAttributes.WorkflowType.Name,
-				Version: *event.ChildWorkflowExecutionTerminatedEventAttributes.WorkflowType.Version,
-				Target:  *event.ChildWorkflowExecutionTerminatedEventAttributes.WorkflowExecution.WorkflowID,
-			}
-
-		// signal externals
-		case swf.EventTypeSignalExternalWorkflowExecutionInitiated:
-			snapshot.Event = &FSMSnapshotEvent{
-				Type:   EventType,
-				Name:   *event.SignalExternalWorkflowExecutionInitiatedEventAttributes.SignalName,
-				Input:  c.tryDeserialize(event.SignalExternalWorkflowExecutionInitiatedEventAttributes.Input),
-				Target: *event.SignalExternalWorkflowExecutionInitiatedEventAttributes.WorkflowID,
-			}
-		case swf.EventTypeSignalExternalWorkflowExecutionFailed:
-			snapshot.Event = &FSMSnapshotEvent{
-				Type:   EventType,
-				Target: *event.SignalExternalWorkflowExecutionFailedEventAttributes.WorkflowID,
-				Output: *event.SignalExternalWorkflowExecutionFailedEventAttributes.Cause,
-			}
-
-		// cancel externals
-		case swf.EventTypeRequestCancelExternalWorkflowExecutionInitiated:
-			snapshot.Event = &FSMSnapshotEvent{
-				Type:   EventType,
-				Target: *event.RequestCancelExternalWorkflowExecutionInitiatedEventAttributes.WorkflowID,
-			}
-
-		// timers
-		case swf.EventTypeTimerStarted:
-			if snapshot.Event != nil && snapshot.Event.Input == c.pointerStartedEventID(event.EventID) {
-				snapshot.Event.Input = *event.TimerStartedEventAttributes.StartToFireTimeout
-			}
-		case swf.EventTypeTimerFired:
-			snapshot.Event = &FSMSnapshotEvent{
-				Type:  EventType,
-				Name:  *event.TimerFiredEventAttributes.TimerID,
-				Input: c.pointerStartedEventID(event.TimerFiredEventAttributes.StartedEventID),
-			}
-
-		// cancellations
-		case swf.EventTypeWorkflowExecutionCancelRequested:
-			snapshot.Event = &FSMSnapshotEvent{
-				Type:   EventType,
-				Source: *swf.WorkflowExecutionCancelRequestedEventAttributes.ExternalWorkflowExecution.WorkflowID,
-				Input:  *swf.WorkflowExecutionCancelRequestedEventAttributes.Cause,
-			}
-		case swf.EventTypeWorkflowExecutionCanceled:
-			snapshot.Event = &FSMSnapshotEvent{
-				Type:   EventType,
-				Output: *swf.WorkflowExecutionCanceledEventAttributes.Details,
-			}
-		case swf.EventTypeCancelWorkflowExecutionFailed:
-			snapshot.Event = &FSMSnapshotEvent{
-				Type:   EventType,
-				Output: *swf.CancelWorkflowExecutionFailedEventAttributes.Cause,
-			}
-
-		// completions
-		case swf.EventTypeWorkflowExecutionCompleted:
-			snapshot.Event = &FSMSnapshotEvent{
-				Type:   EventType,
-				Output: c.tryDeserialize(swf.WorkflowExecutionCompletedEventAttributes.Result),
-			}
-		case swf.EventTypeCompleteWorkflowExecutionFailed:
-			snapshot.Event = &FSMSnapshotEvent{
-				Type:   EventType,
-				Output: swf.CompleteWorkflowExecutionFailedEventAttributes.Cause,
-			}
-
-		// failed
-		case swf.EventTypeWorkflowExecutionFailed:
-			snapshot.Event = &FSMSnapshotEvent{
-				Type: EventType,
-				Output: *swf.WorkflowExecutionFailedEventAttributes.Reason + ": " +
-					swf.WorkflowExecutionFailedEventAttributes.Details,
-			}
-		case swf.EventTypeFailWorkflowExecutionFailed:
-			snapshot.Event = &FSMSnapshotEvent{
-				Type:   EventType,
-				Output: *swf.FailWorkflowExecutionFailedEventAttributes.Cause,
-			}
-
-		// time outs
-		case swf.EventTypeWorkflowExecutionTimedOut:
-			snapshot.Event = &FSMSnapshotEvent{
-				Type:   EventType,
-				Output: *swf.WorkflowExecutionTimedOutEventAttributes.TimeoutType,
-			}
-
-		// continuations
-		case swf.EventTypeWorkflowExecutionContinuedAsNew:
-			snapshot.Event = &FSMSnapshotEvent{
-				Type:   EventType,
-				Input:  c.tryDeserialize(swf.WorkflowExecutionContinuedAsNewEventAttributes.Input),
-				Output: *swf.WorkflowExecutionContinuedAsNewEventAttributes.NewExecutionRunID,
-			}
-		case swf.EventTypeContinueAsNewWorkflowExecutionFailed:
-			snapshot.Event = &FSMSnapshotEvent{
-				Type:   EventType,
-				Output: *swf.ContinueAsNewWorkflowExecutionFailedEventAttributes.Cause,
-			}
-
-		// terminations
-		case swf.EventTypeWorkflowExecutionTerminated:
-			snapshot.Event = &FSMSnapshotEvent{
-				Type: EventType,
-				Output: *swf.WorkflowExecutionTerminatedEventAttributes.Cause + ": " +
-					*swf.WorkflowExecutionTerminatedEventAttributes.Reason + ": " +
-					*swf.WorkflowExecutionTerminatedEventAttributes.Details,
-			}
-
+			nextCorrelator = correlator
+			continue
 		}
 
 		state, err := c.f.statefulHistoryEventToSerializedState(event)
@@ -559,6 +365,11 @@ func (c *client) snapshotsFromHistoryEventIterator(next func() *swf.HistoryEvent
 		}
 
 		if state != nil {
+			if snapshot.State != nil {
+				snapshots = append(snapshots, snapshot)
+				snapshot = FSMSnapshot{Events: []*FSMSnapshotEvent{}}
+			}
+
 			snapshot.State = &FSMSnapshotState{
 				ID:        *event.EventID,
 				Timestamp: *event.EventTimestamp,
@@ -571,33 +382,50 @@ func (c *client) snapshotsFromHistoryEventIterator(next func() *swf.HistoryEvent
 				break
 			}
 
-			snapshots = append(snapshots, snapshot)
-			snapshot = FSMSnapshot{}
+			snapshot.Correlator = nextCorrelator
+			nextCorrelator = nil
+
+			continue
 		}
+
+		eventAttributes, err := c.snapshotEventAttributesMap(event)
+		if err != nil {
+			break
+		}
+		snapshot.Events = append(snapshot.Events, &FSMSnapshotEvent{
+			Type:       *event.EventType,
+			ID:         *event.EventID,
+			Timestamp:  *event.EventTimestamp,
+			Attributes: eventAttributes,
+		})
+	}
+
+	if snapshot.State != nil {
+		snapshots = append(snapshots, snapshot)
 	}
 
 	return snapshots, err
 }
 
-func (c *client) tryDeserialize(serialized *string) interface{} {
-	if serialized == nil || *serialized == "" {
-		return ""
+func (c *client) snapshotEventAttributesMap(e *swf.HistoryEvent) (map[string]interface{}, error) {
+	attrStruct := reflect.ValueOf(*e).FieldByName(*e.EventType + "EventAttributes").Interface()
+	attrJsonBytes, err := json.Marshal(attrStruct)
+	if err != nil {
+		return nil, err
 	}
 
-	tryMap := make(map[string]interface{})
-	err := c.f.systemSerializer.Deserialize(*serialized, &tryMap)
-	if err == nil {
-		return tryMap
+	attrMap := make(map[string]interface{})
+	err = json.Unmarshal(attrJsonBytes, &attrMap)
+	if err != nil {
+		return nil, err
 	}
-	log.Printf("component=client fn=trySystemDeserialize at=deserialize-map error=%s", err)
 
-	return *serialized
-}
-
-func (c *client) pointerStartedEventID(id *int64) string {
-	return fmt.Sprintf("StartedEventID->%d", *id)
-}
-
-func (c *client) pointerScheduledEventID(id *int64) string {
-	return fmt.Sprintf("ScheduledEventID->%d", *id)
+	for k, v := range attrMap {
+		tryValueMap := make(map[string]interface{})
+		tryErr := json.Unmarshal([]byte(fmt.Sprint(v)), &tryValueMap)
+		if tryErr == nil {
+			attrMap[k] = tryValueMap
+		}
+	}
+	return attrMap, nil
 }

--- a/fsm/client.go
+++ b/fsm/client.go
@@ -335,8 +335,8 @@ func (c *client) snapshotsFromHistoryEventIterator(next func() *swf.HistoryEvent
 	snapshots := []FSMSnapshot{}
 	var err error
 
+	snapshot := FSMSnapshot{}
 	for event := next(); event != nil; event = next() {
-		snapshot := FSMSnapshot{}
 
 		// TODO: how to deal with failure events?
 		switch EventType := *event.EventType; EventType {
@@ -418,6 +418,7 @@ func (c *client) snapshotsFromHistoryEventIterator(next func() *swf.HistoryEvent
 			}
 
 			snapshots = append(snapshots, snapshot)
+			snapshot = FSMSnapshot{}
 		}
 	}
 

--- a/fsm/client_test.go
+++ b/fsm/client_test.go
@@ -130,11 +130,7 @@ func TestClient(t *testing.T) {
 		t.Fatalf("snapshots length: %d", length)
 	}
 
-	if name := snapshots[0].Event.Name; name != "start" {
-		t.Fatalf("snapshots[0].Event.Name: %s ", name)
-	}
-
-	if Type := snapshots[0].Event.Type; Type != swf.EventTypeWorkflowExecutionStarted {
+	if Type := snapshots[0].Events[0].Type; Type != swf.EventTypeWorkflowExecutionStarted {
 		t.Fatalf("snapshots[0].Event.Type: %s ", Type)
 	}
 

--- a/fsm/fsm_models.go
+++ b/fsm/fsm_models.go
@@ -402,6 +402,7 @@ type FSMSnapshotEvent struct {
 	Timestamp  time.Time
 	Type       string
 	Attributes map[string]interface{}
+	References []int64
 }
 
 // StartFSMWorkflowInput should be used to construct the input for any StartWorkflowExecutionRequests.

--- a/fsm/fsm_models.go
+++ b/fsm/fsm_models.go
@@ -384,9 +384,9 @@ type SerializedActivityState struct {
 }
 
 type FSMSnapshot struct {
-	State *FSMSnapshotState
-	Event *FSMSnapshotEvent
-	//	Actions // TODO: separate Actions from Events?
+	State      *FSMSnapshotState
+	Correlator *EventCorrelator
+	Events     []*FSMSnapshotEvent
 }
 
 type FSMSnapshotState struct {
@@ -398,13 +398,10 @@ type FSMSnapshotState struct {
 }
 
 type FSMSnapshotEvent struct {
-	Type    string
-	Name    string
-	Version string
-	Source  string
-	Target  string
-	Input   interface{}
-	Output  interface{}
+	ID         int64
+	Timestamp  time.Time
+	Type       string
+	Attributes map[string]interface{}
 }
 
 // StartFSMWorkflowInput should be used to construct the input for any StartWorkflowExecutionRequests.


### PR DESCRIPTION
This changes `FSMSnapshot` from "fuzzy compacting" `HistoryEvents` in the gigantic `switch`to just passing through all the events as-is, but changing the event attributes into a unified `map[string]interface` for easier client access. This also includes the correlation data and referencing events in snapshots.