### PR TITLE
Snapshots streams

### DIFF
--- a/awsinternal/jsonutil/unmarshal.go
+++ b/awsinternal/jsonutil/unmarshal.go
@@ -1,0 +1,218 @@
+package jsonutil
+
+// copied from github.com/aws/aws-sdk-go/internal/protocol/json/jsonutil/unmarshal.go
+// to give access to AWS-internal unmarshalling disallowed in go 1.5.
+// do not use for anything in the critical path. use AWS public packages where possible.
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"reflect"
+	"strings"
+	"time"
+)
+
+// UnmarshalJSON reads a stream and unmarshals the results in object v.
+func UnmarshalJSON(v interface{}, stream io.Reader) error {
+	var out interface{}
+
+	b, err := ioutil.ReadAll(stream)
+	if err != nil {
+		return err
+	}
+
+	if len(b) == 0 {
+		return nil
+	}
+
+	if err := json.Unmarshal(b, &out); err != nil {
+		return err
+	}
+
+	return unmarshalAny(reflect.ValueOf(v), out, "")
+}
+
+func unmarshalAny(value reflect.Value, data interface{}, tag reflect.StructTag) error {
+	vtype := value.Type()
+	if vtype.Kind() == reflect.Ptr {
+		vtype = vtype.Elem() // check kind of actual element type
+	}
+
+	t := tag.Get("type")
+	if t == "" {
+		switch vtype.Kind() {
+		case reflect.Struct:
+			// also it can't be a time object
+			if _, ok := value.Interface().(*time.Time); !ok {
+				t = "structure"
+			}
+		case reflect.Slice:
+			// also it can't be a byte slice
+			if _, ok := value.Interface().([]byte); !ok {
+				t = "list"
+			}
+		case reflect.Map:
+			t = "map"
+		}
+	}
+
+	switch t {
+	case "structure":
+		if field, ok := vtype.FieldByName("SDKShapeTraits"); ok {
+			tag = field.Tag
+		}
+		return unmarshalStruct(value, data, tag)
+	case "list":
+		return unmarshalList(value, data, tag)
+	case "map":
+		return unmarshalMap(value, data, tag)
+	default:
+		return unmarshalScalar(value, data, tag)
+	}
+}
+
+func unmarshalStruct(value reflect.Value, data interface{}, tag reflect.StructTag) error {
+	if data == nil {
+		return nil
+	}
+	mapData, ok := data.(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("JSON value is not a structure (%#v)", data)
+	}
+
+	t := value.Type()
+	if value.Kind() == reflect.Ptr {
+		if value.IsNil() { // create the structure if it's nil
+			s := reflect.New(value.Type().Elem())
+			value.Set(s)
+			value = s
+		}
+
+		value = value.Elem()
+		t = t.Elem()
+	}
+
+	// unwrap any payloads
+	if payload := tag.Get("payload"); payload != "" {
+		field, _ := t.FieldByName(payload)
+		return unmarshalAny(value.FieldByName(payload), data, field.Tag)
+	}
+
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		if c := field.Name[0:1]; strings.ToLower(c) == c {
+			continue // ignore unexported fields
+		}
+
+		// figure out what this field is called
+		name := field.Name
+		if locName := field.Tag.Get("locationName"); locName != "" {
+			name = locName
+		}
+
+		member := value.FieldByName(field.Name)
+		err := unmarshalAny(member, mapData[name], field.Tag)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func unmarshalList(value reflect.Value, data interface{}, tag reflect.StructTag) error {
+	if data == nil {
+		return nil
+	}
+	listData, ok := data.([]interface{})
+	if !ok {
+		return fmt.Errorf("JSON value is not a list (%#v)", data)
+	}
+
+	if value.IsNil() {
+		l := len(listData)
+		value.Set(reflect.MakeSlice(value.Type(), l, l))
+	}
+
+	for i, c := range listData {
+		err := unmarshalAny(value.Index(i), c, "")
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func unmarshalMap(value reflect.Value, data interface{}, tag reflect.StructTag) error {
+	if data == nil {
+		return nil
+	}
+	mapData, ok := data.(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("JSON value is not a map (%#v)", data)
+	}
+
+	if value.IsNil() {
+		value.Set(reflect.MakeMap(value.Type()))
+	}
+
+	for k, v := range mapData {
+		kvalue := reflect.ValueOf(k)
+		vvalue := reflect.New(value.Type().Elem()).Elem()
+
+		unmarshalAny(vvalue, v, "")
+		value.SetMapIndex(kvalue, vvalue)
+	}
+
+	return nil
+}
+
+func unmarshalScalar(value reflect.Value, data interface{}, tag reflect.StructTag) error {
+	errf := func() error {
+		return fmt.Errorf("unsupported value: %v (%s)", value.Interface(), value.Type())
+	}
+
+	switch d := data.(type) {
+	case nil:
+		return nil // nothing to do here
+	case string:
+		switch value.Interface().(type) {
+		case *string:
+			value.Set(reflect.ValueOf(&d))
+		case []byte:
+			b, err := base64.StdEncoding.DecodeString(d)
+			if err != nil {
+				return err
+			}
+			value.Set(reflect.ValueOf(b))
+		default:
+			return errf()
+		}
+	case float64:
+		switch value.Interface().(type) {
+		case *int64:
+			di := int64(d)
+			value.Set(reflect.ValueOf(&di))
+		case *float64:
+			value.Set(reflect.ValueOf(&d))
+		case *time.Time:
+			t := time.Unix(int64(d), 0).UTC()
+			value.Set(reflect.ValueOf(&t))
+		default:
+			return errf()
+		}
+	case bool:
+		switch value.Interface().(type) {
+		case *bool:
+			value.Set(reflect.ValueOf(&d))
+		default:
+			return errf()
+		}
+	default:
+		return fmt.Errorf("unsupported JSON value (%v)", data)
+	}
+	return nil
+}

--- a/fsm/client.go
+++ b/fsm/client.go
@@ -35,6 +35,7 @@ type FSMClient interface {
 	Start(startTemplate swf.StartWorkflowExecutionInput, id string, input interface{}) (*swf.StartWorkflowExecutionOutput, error)
 	RequestCancel(id string) error
 	GetHistoryEventIteratorFromWorkflowID(workflowID string) (HistoryEventIterator, error)
+	GetHistoryEventIteratorFromWorkflowExecution(execution *swf.WorkflowExecution) (HistoryEventIterator, error)
 	GetHistoryEventIteratorFromReader(reader io.Reader) (HistoryEventIterator, error)
 }
 
@@ -300,7 +301,10 @@ func (c *client) GetHistoryEventIteratorFromWorkflowID(workflowID string) (Histo
 	if err != nil {
 		return nil, err
 	}
+	return c.GetHistoryEventIteratorFromWorkflowExecution(execution)
+}
 
+func (c *client) GetHistoryEventIteratorFromWorkflowExecution(execution *swf.WorkflowExecution) (HistoryEventIterator, error) {
 	req := &swf.GetWorkflowExecutionHistoryInput{
 		Domain:       S(c.f.Domain),
 		Execution:    execution,

--- a/fsm/client_test.go
+++ b/fsm/client_test.go
@@ -130,19 +130,19 @@ func TestClient(t *testing.T) {
 		t.Fatalf("snapshots length: %d", length)
 	}
 
-	if Type := snapshots[0].Events[0].Type; Type != swf.EventTypeWorkflowExecutionStarted {
+	if Type := *snapshots[0].Events[0].Type; Type != swf.EventTypeWorkflowExecutionStarted {
 		t.Fatalf("snapshots[0].Event.Type: %s ", Type)
 	}
 
-	if name := snapshots[0].State.Name; name != "initial" {
+	if name := *snapshots[0].State.Name; name != "initial" {
 		t.Fatalf("snapshots[0].State.Name: %s ", name)
 	}
 
-	if version := snapshots[0].State.Version; version != 0 {
+	if version := *snapshots[0].State.Version; version != 0 {
 		t.Fatalf("snapshots[0].State.Version: %d ", version)
 	}
 
-	if id := snapshots[0].State.ID; id != 1 {
+	if id := *snapshots[0].State.ID; id != 1 {
 		t.Fatalf("snapshots[0].State.ID: %d ", id)
 	}
 

--- a/fsm/fsm_models.go
+++ b/fsm/fsm_models.go
@@ -6,8 +6,6 @@ import (
 	"encoding/json"
 	"strings"
 
-	"time"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/swf"
 	"github.com/golang/protobuf/proto"
@@ -381,28 +379,6 @@ type SerializedErrorState struct {
 type SerializedActivityState struct {
 	ActivityID string
 	Input      *string
-}
-
-type FSMSnapshot struct {
-	State      *FSMSnapshotState
-	Correlator *EventCorrelator
-	Events     []*FSMSnapshotEvent
-}
-
-type FSMSnapshotState struct {
-	ID        *int64
-	Timestamp *time.Time
-	Version   *uint64
-	Name      *string
-	Data      *interface{}
-}
-
-type FSMSnapshotEvent struct {
-	ID         *int64
-	Timestamp  *time.Time
-	Type       *string
-	Attributes *map[string]interface{}
-	References []*int64
 }
 
 // StartFSMWorkflowInput should be used to construct the input for any StartWorkflowExecutionRequests.

--- a/fsm/fsm_models.go
+++ b/fsm/fsm_models.go
@@ -390,19 +390,19 @@ type FSMSnapshot struct {
 }
 
 type FSMSnapshotState struct {
-	ID        int64
-	Timestamp time.Time
-	Version   uint64
-	Name      string
-	Data      interface{}
+	ID        *int64
+	Timestamp *time.Time
+	Version   *uint64
+	Name      *string
+	Data      *interface{}
 }
 
 type FSMSnapshotEvent struct {
-	ID         int64
-	Timestamp  time.Time
-	Type       string
-	Attributes map[string]interface{}
-	References []int64
+	ID         *int64
+	Timestamp  *time.Time
+	Type       *string
+	Attributes *map[string]interface{}
+	References []*int64
 }
 
 // StartFSMWorkflowInput should be used to construct the input for any StartWorkflowExecutionRequests.

--- a/fsm/snapshots.go
+++ b/fsm/snapshots.go
@@ -1,0 +1,199 @@
+package fsm
+
+import (
+	"fmt"
+
+	"strings"
+
+	"encoding/json"
+	"reflect"
+
+	"strconv"
+
+	"io"
+	"time"
+
+	"github.com/aws/aws-sdk-go/service/swf"
+	. "github.com/sclasen/swfsm/sugar"
+)
+
+type FSMSnapshot struct {
+	State      *FSMSnapshotState
+	Correlator *EventCorrelator
+	Events     []*FSMSnapshotEvent
+}
+
+type FSMSnapshotState struct {
+	ID        *int64
+	Timestamp *time.Time
+	Version   *uint64
+	Name      *string
+	Data      *interface{}
+}
+
+type FSMSnapshotEvent struct {
+	ID         *int64
+	Timestamp  *time.Time
+	Type       *string
+	Attributes *map[string]interface{}
+	References []*int64
+}
+
+type Snapshotter interface {
+	FromWorkflowID(id string) ([]FSMSnapshot, error)
+	FromWorkflowExecution(exec *swf.WorkflowExecution) ([]FSMSnapshot, error)
+	FromReader(reader io.Reader) ([]FSMSnapshot, error)
+	FromHistoryEventIterator(itr HistoryEventIterator) ([]FSMSnapshot, error)
+}
+
+type snapshotter struct {
+	c *client
+}
+
+func newSnapshotter(c *client) Snapshotter {
+	return &snapshotter{
+		c: c,
+	}
+}
+
+func (s *snapshotter) FromWorkflowID(id string) ([]FSMSnapshot, error) {
+	itr, err := s.c.GetHistoryEventIteratorFromWorkflowID(id)
+	if err != nil {
+		return nil, err
+	}
+	return s.FromHistoryEventIterator(itr)
+}
+
+func (s *snapshotter) FromWorkflowExecution(exec *swf.WorkflowExecution) ([]FSMSnapshot, error) {
+	itr, err := s.c.GetHistoryEventIteratorFromWorkflowExecution(exec)
+	if err != nil {
+		return nil, err
+	}
+	return s.FromHistoryEventIterator(itr)
+}
+
+func (s *snapshotter) FromReader(reader io.Reader) ([]FSMSnapshot, error) {
+	itr, err := s.c.GetHistoryEventIteratorFromReader(reader)
+	if err != nil {
+		return nil, err
+	}
+	return s.FromHistoryEventIterator(itr)
+}
+
+func (s *snapshotter) FromHistoryEventIterator(itr HistoryEventIterator) ([]FSMSnapshot, error) {
+	snapshots := []FSMSnapshot{}
+	var err error
+
+	zero := s.c.f.zeroStateData()
+	unrecordedName := "<unrecorded>"
+	unrecordedID := int64(999999)
+	unrecordedVersion := uint64(999999)
+
+	refs := make(map[int64][]*int64)
+	snapshot := FSMSnapshot{Events: []*FSMSnapshotEvent{}}
+	var nextCorrelator *EventCorrelator
+	event, err := itr()
+	for ; event != nil; event, err = itr() {
+		if err != nil {
+			return snapshots, err
+		}
+
+		if s.c.f.isCorrelatorMarker(event) {
+			correlator, err := s.c.f.findSerializedEventCorrelator([]*swf.HistoryEvent{event})
+			if err != nil {
+				break
+			}
+			nextCorrelator = correlator
+			continue
+		}
+
+		state, err := s.c.f.statefulHistoryEventToSerializedState(event)
+		if err != nil {
+			break
+		}
+
+		if state != nil {
+			if snapshot.State != nil {
+				snapshots = append(snapshots, snapshot)
+				snapshot = FSMSnapshot{Events: []*FSMSnapshotEvent{}}
+			}
+
+			snapshot.State = &FSMSnapshotState{
+				ID:        event.EventID,
+				Timestamp: event.EventTimestamp,
+				Version:   &state.StateVersion,
+				Name:      S(state.StateName),
+				Data:      &zero,
+			}
+			err = s.c.f.Serializer.Deserialize(state.StateData, snapshot.State.Data)
+			if err != nil {
+				break
+			}
+
+			snapshot.Correlator = nextCorrelator
+			nextCorrelator = nil
+
+			continue
+		}
+
+		if snapshot.State == nil {
+			snapshot.State = &FSMSnapshotState{
+				Name:    &unrecordedName,
+				ID:      &(unrecordedID),
+				Version: &unrecordedVersion,
+			}
+		}
+
+		eventAttributes, err := s.snapshotEventAttributesMap(event)
+		if err != nil {
+			break
+		}
+
+		for key, value := range eventAttributes {
+			if strings.HasSuffix(key, "EventID") {
+				parsed, err := strconv.ParseInt(fmt.Sprint(value), 10, 64)
+				if err != nil {
+					break
+				}
+				refs[parsed] = append(refs[parsed], event.EventID)
+			}
+		}
+
+		snapshot.Events = append(snapshot.Events, &FSMSnapshotEvent{
+			Type:       event.EventType,
+			ID:         event.EventID,
+			Timestamp:  event.EventTimestamp,
+			Attributes: &eventAttributes,
+			References: refs[*event.EventID],
+		})
+	}
+
+	if snapshot.State != nil {
+		snapshots = append(snapshots, snapshot)
+	}
+
+	return snapshots, err
+}
+
+func (s *snapshotter) snapshotEventAttributesMap(e *swf.HistoryEvent) (map[string]interface{}, error) {
+	attrStruct := reflect.ValueOf(*e).FieldByName(*e.EventType + "EventAttributes").Interface()
+	attrJsonBytes, err := json.Marshal(attrStruct)
+	if err != nil {
+		return nil, err
+	}
+
+	attrMap := make(map[string]interface{})
+	err = json.Unmarshal(attrJsonBytes, &attrMap)
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range attrMap {
+		tryValueMap := make(map[string]interface{})
+		tryErr := json.Unmarshal([]byte(fmt.Sprint(v)), &tryValueMap)
+		if tryErr == nil {
+			attrMap[k] = tryValueMap
+		}
+	}
+	return attrMap, nil
+}


### PR DESCRIPTION
Adds support to read snapshots from a stream (i.e. a JSON file of SWF history events output from the AWS CLI). Because these files use AWS's special JSON RPC format, I had to pull in their internal JSON decoder. Let me know if there was a better way to do this.

This also adds a `HistoryEventIterator` for more flexibility between the producers and consumers. Along with streams, iterators can also be created from `WorkflowExecution`s for more efficient look ups by tag and future support for querying by runID.