### PR TITLE
Fix FSMClient.FindAll ordering

### DIFF
--- a/fsm/client_test.go
+++ b/fsm/client_test.go
@@ -439,7 +439,7 @@ func TestFindAll_Max(t *testing.T) {
 		t.Fatal(output.ExecutionInfos)
 	}
 
-	if *output.ExecutionInfos[0].Execution.WorkflowId != "open-1" {
+	if *output.ExecutionInfos[0].Execution.WorkflowId != "closed-1" {
 		t.Fatal(output.ExecutionInfos)
 	}
 
@@ -505,13 +505,13 @@ func TestFindAll_ReverseOrder_Interleaving(t *testing.T) {
 		t.Fatal(output.ExecutionInfos)
 	}
 
-	if *output.ExecutionInfos[0].Execution.WorkflowId != "C-open" {
+	if *output.ExecutionInfos[0].Execution.WorkflowId != "A-open" {
 		t.Fatal(output.ExecutionInfos)
 	}
 	if *output.ExecutionInfos[1].Execution.WorkflowId != "B-closed" {
 		t.Fatal(output.ExecutionInfos)
 	}
-	if *output.ExecutionInfos[2].Execution.WorkflowId != "A-open" {
+	if *output.ExecutionInfos[2].Execution.WorkflowId != "C-open" {
 		t.Fatal(output.ExecutionInfos)
 	}
 
@@ -527,7 +527,7 @@ func TestFindAll_FindLatestByWorkflowID(t *testing.T) {
 			WorkflowId: aws.String("workflow-A"),
 		},
 		MaximumPageSize: aws.Int64(int64(1)),
-		ReverseOrder:    aws.Bool(true),
+		ReverseOrder:    aws.Bool(false),
 		StartTimeFilter: &swf.ExecutionTimeFilter{OldestDate: aws.Time(time.Unix(0, 0))},
 	}
 	mockSwf.MockOnTyped_ListOpenWorkflowExecutions(expectedOpenInput).Return(

--- a/fsm/finder.go
+++ b/fsm/finder.go
@@ -237,10 +237,11 @@ func (f *finder) applyInputLocally(input *FindInput, infos []*swf.WorkflowExecut
 		applied = append(applied, info)
 	}
 
+	// swf default order is descending, so reverseOrder is ascending
 	if input.ReverseOrder != nil && *input.ReverseOrder {
-		sort.Sort(sort.Reverse(sortExecutionInfos(applied)))
-	} else {
 		sort.Sort(sortExecutionInfos(applied))
+	} else {
+		sort.Sort(sort.Reverse(sortExecutionInfos(applied)))
 	}
 
 	if input.MaximumPageSize != nil && *input.MaximumPageSize > 0 && int64(len(applied)) > *input.MaximumPageSize {
@@ -262,7 +263,7 @@ func (f *finder) FindLatestByWorkflowID(workflowID string) (exec *swf.WorkflowEx
 	output, err := f.FindAll(&FindInput{
 		StatusFilter:    FilterStatusOpenPriority,
 		MaximumPageSize: I(1),
-		ReverseOrder:    aws.Bool(true),
+		ReverseOrder:    aws.Bool(false), // keep descending default
 		StartTimeFilter: &swf.ExecutionTimeFilter{OldestDate: aws.Time(time.Unix(0, 0))},
 		ExecutionFilter: &swf.WorkflowExecutionFilter{
 			WorkflowId: S(workflowID),


### PR DESCRIPTION
I mistakenly thought that `ReverseOrder` meant descending,
but the default is already descending, so `ReverseOrder`
changes the results to be ascending. This reverses the sort logic
accordingly.