### PR TITLE
Fix history segment state data + tests + error state

### DIFF
--- a/Godeps/_workspace/src/github.com/stretchr/testify/mock/mock.go
+++ b/Godeps/_workspace/src/github.com/stretchr/testify/mock/mock.go
@@ -2,13 +2,14 @@ package mock
 
 import (
 	"fmt"
-	"github.com/stretchr/objx"
-	"github.com/stretchr/testify/assert"
 	"reflect"
 	"runtime"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/stretchr/objx"
+	"github.com/stretchr/testify/assert"
 )
 
 // TestingT is an interface wrapper around *testing.T

--- a/fsm/client_test.go
+++ b/fsm/client_test.go
@@ -565,7 +565,6 @@ func TestSegmentHistory(t *testing.T) {
 	var startData interface{}
 	startData = TestData{States: []string{"start data"}}
 
-	workflowId := "workflow-id"
 	activityId := "activity-id"
 	activityData := "activity data"
 
@@ -596,7 +595,6 @@ func TestSegmentHistory(t *testing.T) {
 					StateVersion: 1,
 					StateName:    "ready",
 					StateData:    fsm.Serialize(readyData),
-					WorkflowId:   workflowId,
 				})),
 			},
 		},
@@ -628,7 +626,6 @@ func TestSegmentHistory(t *testing.T) {
 
 	expected := []HistorySegment{
 		HistorySegment{
-			//			WorkflowId: aws.String(workflowId),
 			State: &HistorySegmentState{
 				ID:      aws.Int64(999999),
 				Version: uInt64(999999),
@@ -657,7 +654,6 @@ func TestSegmentHistory(t *testing.T) {
 			},
 		},
 		HistorySegment{
-			WorkflowId: aws.String(workflowId),
 			State: &HistorySegmentState{
 				ID:      aws.Int64(5),
 				Version: uInt64(1),
@@ -690,7 +686,6 @@ func TestSegmentHistory(t *testing.T) {
 			},
 			Correlator: nil,
 			Events:     []*HistorySegmentEvent{},
-			WorkflowId: aws.String(""), // TODO: this is caused by a bug in initial serialization
 		},
 	}
 

--- a/fsm/client_test.go
+++ b/fsm/client_test.go
@@ -556,8 +556,172 @@ func TestFindAll_FindLatestByWorkflowID(t *testing.T) {
 	mockSwf.AssertExpectations(t)
 }
 
+func TestSegmentHistory(t *testing.T) {
+	fsm := dummyFsm()
+
+	var readyData interface{}
+	readyData = TestData{States: []string{"ready data"}}
+
+	var startData interface{}
+	startData = TestData{States: []string{"start data"}}
+
+	workflowId := "workflow-id"
+	activityId := "activity-id"
+	activityData := "activity data"
+
+	itr := sliceHistoryIterator(t, []*swf.HistoryEvent{
+		&swf.HistoryEvent{
+			EventId:   aws.Int64(7),
+			EventType: aws.String(swf.EventTypeActivityTaskScheduled),
+			ActivityTaskScheduledEventAttributes: &swf.ActivityTaskScheduledEventAttributes{
+				ActivityId: aws.String(activityId),
+				Input:      aws.String(fsm.Serialize(activityData)),
+				DecisionTaskCompletedEventId: aws.Int64(4),
+			},
+		},
+		&swf.HistoryEvent{
+			EventId:   aws.Int64(6),
+			EventType: aws.String(swf.EventTypeMarkerRecorded),
+			MarkerRecordedEventAttributes: &swf.MarkerRecordedEventAttributes{
+				MarkerName: aws.String(CorrelatorMarker),
+				Details:    aws.String(fsm.Serialize(EventCorrelator{})),
+			},
+		},
+		&swf.HistoryEvent{
+			EventId:   aws.Int64(5),
+			EventType: aws.String(swf.EventTypeMarkerRecorded),
+			MarkerRecordedEventAttributes: &swf.MarkerRecordedEventAttributes{
+				MarkerName: aws.String(StateMarker),
+				Details: aws.String(fsm.Serialize(SerializedState{
+					StateVersion: 1,
+					StateName:    "ready",
+					StateData:    fsm.Serialize(readyData),
+					WorkflowId:   workflowId,
+				})),
+			},
+		},
+		&swf.HistoryEvent{
+			EventId:   aws.Int64(4),
+			EventType: aws.String(swf.EventTypeDecisionTaskCompleted),
+		},
+		&swf.HistoryEvent{
+			EventId:   aws.Int64(3),
+			EventType: aws.String(swf.EventTypeDecisionTaskStarted),
+		},
+		&swf.HistoryEvent{
+			EventId:   aws.Int64(2),
+			EventType: aws.String(swf.EventTypeDecisionTaskScheduled),
+		},
+		&swf.HistoryEvent{
+			EventId:   aws.Int64(1),
+			EventType: aws.String(swf.EventTypeWorkflowExecutionStarted),
+			WorkflowExecutionStartedEventAttributes: &swf.WorkflowExecutionStartedEventAttributes{
+				Input: StartFSMWorkflowInput(fsm, &startData),
+			},
+		},
+	})
+
+	actual, err := NewFSMClient(fsm, &mocks.SWFAPI{}).SegmentHistory(itr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := []HistorySegment{
+		HistorySegment{
+			//			WorkflowId: aws.String(workflowId),
+			State: &HistorySegmentState{
+				ID:      aws.Int64(999999),
+				Version: uInt64(999999),
+				Name:    aws.String("<unrecorded>"),
+				Data:    nil,
+			},
+			Correlator: nil,
+			Events: []*HistorySegmentEvent{
+				&HistorySegmentEvent{
+					ID:   aws.Int64(7),
+					Type: aws.String(swf.EventTypeActivityTaskScheduled),
+					Attributes: &map[string]interface{}{
+						"ActivityId":                   activityId,
+						"ActivityType":                 nil,
+						"Control":                      nil,
+						"DecisionTaskCompletedEventId": 4,
+						"HeartbeatTimeout":             nil,
+						"Input":                        fsm.Serialize(activityData), // TODO: un-double escape?
+						"ScheduleToCloseTimeout":       nil,
+						"ScheduleToStartTimeout":       nil,
+						"StartToCloseTimeout":          nil,
+						"TaskList":                     nil,
+						"TaskPriority":                 nil,
+					},
+				},
+			},
+		},
+		HistorySegment{
+			WorkflowId: aws.String(workflowId),
+			State: &HistorySegmentState{
+				ID:      aws.Int64(5),
+				Version: uInt64(1),
+				Name:    aws.String("ready"),
+				Data:    &readyData,
+			},
+			Correlator: &EventCorrelator{},
+			Events: []*HistorySegmentEvent{
+				&HistorySegmentEvent{
+					ID:         aws.Int64(4),
+					Type:       aws.String(swf.EventTypeDecisionTaskCompleted),
+					References: []*int64{aws.Int64(7)},
+				},
+				&HistorySegmentEvent{
+					ID:   aws.Int64(3),
+					Type: aws.String(swf.EventTypeDecisionTaskStarted),
+				},
+				&HistorySegmentEvent{
+					ID:   aws.Int64(2),
+					Type: aws.String(swf.EventTypeDecisionTaskScheduled),
+				},
+			},
+		},
+		HistorySegment{
+			State: &HistorySegmentState{
+				ID:      aws.Int64(1),
+				Version: uInt64(0),
+				Name:    aws.String("initial"),
+				Data:    &startData,
+			},
+			Correlator: nil,
+			Events:     []*HistorySegmentEvent{},
+			WorkflowId: aws.String(""), // TODO: this is caused by a bug in initial serialization
+		},
+	}
+
+	for i, e := range expected {
+		a := actual[i]
+		if fsm.Serialize(e) != fsm.Serialize(a) {
+			t.Logf("expected[%d]:\n%#v\n\n actual[%d]:\n%#v", i, fsm.Serialize(e), i, fsm.Serialize(a))
+			t.FailNow()
+		}
+	}
+}
+
+func uInt64(v uint64) *uint64 {
+	return &v
+}
+
+func sliceHistoryIterator(t *testing.T, events []*swf.HistoryEvent) HistoryEventIterator {
+	cursor := 0
+	return func() (*swf.HistoryEvent, error) {
+		if cursor >= len(events) {
+			return nil, nil
+		}
+		event := events[cursor]
+		cursor++
+		t.Log(event)
+		return event, nil
+	}
+}
+
 func dummyFsm() *FSM {
-	return &FSM{
+	fsm := &FSM{
 		Domain:           "client-test",
 		Name:             "test-fsm",
 		DataType:         TestData{},
@@ -565,4 +729,12 @@ func dummyFsm() *FSM {
 		systemSerializer: JSONStateSerializer{},
 		allowPanics:      false,
 	}
+
+	fsm.AddInitialState(&FSMState{Name: "initial",
+		Decider: func(ctx *FSMContext, h *swf.HistoryEvent, data interface{}) Outcome {
+			return ctx.Stay(data, ctx.EmptyDecisions())
+		},
+	})
+
+	return fsm
 }

--- a/fsm/history_segments.go
+++ b/fsm/history_segments.go
@@ -20,7 +20,6 @@ type HistorySegment struct {
 	State                   *HistorySegmentState
 	Correlator              *EventCorrelator
 	Events                  []*HistorySegmentEvent
-	WorkflowId              *string
 	ContinuedExecutionRunId *string
 }
 
@@ -99,8 +98,6 @@ func (s *historySegmentor) FromHistoryEventIterator(itr HistoryEventIterator) ([
 			if err != nil {
 				return segments, err
 			}
-
-			segment.WorkflowId = &state.WorkflowId
 
 			if event.WorkflowExecutionStartedEventAttributes != nil {
 				segment.ContinuedExecutionRunId = event.WorkflowExecutionStartedEventAttributes.ContinuedExecutionRunId

--- a/fsm/history_segments.go
+++ b/fsm/history_segments.go
@@ -70,7 +70,7 @@ func (s *historySegmentor) FromHistoryEventIterator(itr HistoryEventIterator) ([
 		if s.c.f.isCorrelatorMarker(event) {
 			correlator, err := s.c.f.findSerializedEventCorrelator([]*swf.HistoryEvent{event})
 			if err != nil {
-				break
+				return segments, err
 			}
 			nextCorrelator = correlator
 			continue
@@ -78,7 +78,7 @@ func (s *historySegmentor) FromHistoryEventIterator(itr HistoryEventIterator) ([
 
 		state, err := s.c.f.statefulHistoryEventToSerializedState(event)
 		if err != nil {
-			break
+			return segments, err
 		}
 
 		if state != nil {
@@ -97,7 +97,7 @@ func (s *historySegmentor) FromHistoryEventIterator(itr HistoryEventIterator) ([
 			}
 			err = s.c.f.Serializer.Deserialize(state.StateData, segment.State.Data)
 			if err != nil {
-				break
+				return segments, err
 			}
 
 			segment.WorkflowId = &state.WorkflowId
@@ -122,14 +122,14 @@ func (s *historySegmentor) FromHistoryEventIterator(itr HistoryEventIterator) ([
 
 		eventAttributes, err := s.transformHistoryEventAttributes(event)
 		if err != nil {
-			break
+			return segments, err
 		}
 
 		for key, value := range eventAttributes {
 			if strings.HasSuffix(key, "EventId") {
 				parsed, err := strconv.ParseInt(fmt.Sprint(value), 10, 64)
 				if err != nil {
-					break
+					return segments, err
 				}
 				refs[parsed] = append(refs[parsed], event.EventId)
 			}

--- a/fsm/history_segments.go
+++ b/fsm/history_segments.go
@@ -54,7 +54,6 @@ func (s *historySegmentor) FromHistoryEventIterator(itr HistoryEventIterator) ([
 	segments := []HistorySegment{}
 	var err error
 
-	zero := s.c.f.zeroStateData()
 	unrecordedName := "<unrecorded>"
 	unrecordedId := int64(999999)
 	unrecordedVersion := uint64(999999)
@@ -88,12 +87,13 @@ func (s *historySegmentor) FromHistoryEventIterator(itr HistoryEventIterator) ([
 				segment = HistorySegment{Events: []*HistorySegmentEvent{}}
 			}
 
+			data := s.c.f.zeroStateData()
 			segment.State = &HistorySegmentState{
 				ID:        event.EventId,
 				Timestamp: event.EventTimestamp,
 				Version:   &state.StateVersion,
 				Name:      S(state.StateName),
-				Data:      &zero,
+				Data:      &data,
 			}
 			err = s.c.f.Serializer.Deserialize(state.StateData, segment.State.Data)
 			if err != nil {


### PR DESCRIPTION
This fixes a bug with the `HistorySegment.State.Data` pointing being the same for all segments. It also adds unit tests to avoid this in the future and records the `SerializedErrorState` to include all the types of markers.