### PR TITLE
Record notHandled error in SerializedErrorState

### DIFF
--- a/fsm/fsm_models.go
+++ b/fsm/fsm_models.go
@@ -370,6 +370,7 @@ type SerializedState struct {
 
 //ErrorState is used as the input to a marker that signifies that the workflow is in an error state.
 type SerializedErrorState struct {
+	Details                    string
 	EarliestUnprocessedEventId int64
 	LatestUnprocessedEventId   int64
 	ErrorEvent                 *swf.HistoryEvent


### PR DESCRIPTION
When a non-handled error was detected, it was being added to the `ErrorMarker`, but then returning the error from `Tick`, which never completed the decision. This serializes the error in the marker and returns a `nil` error so that it gets properly recorded.