### PR TITLE
Prefer GetWorkflowExecutionHistoryPages to HistoryEventIterator

### DIFF
--- a/fsm/client.go
+++ b/fsm/client.go
@@ -31,7 +31,7 @@ type FSMClient interface {
 	GetWorkflowExecutionHistoryFromReader(reader io.Reader) (*swf.GetWorkflowExecutionHistoryOutput, error)
 	FindAll(input *FindInput) (output *FindOutput, err error)
 	FindLatestByWorkflowID(workflowID string) (exec *swf.WorkflowExecution, err error)
-	NewHistorySegmentor(sink func(HistorySegment)) HistorySegmentor
+	NewHistorySegmentor() HistorySegmentor
 }
 
 type ClientSWFOps interface {
@@ -243,8 +243,8 @@ func (c *client) GetWorkflowExecutionHistoryFromReader(reader io.Reader) (*swf.G
 	return history, nil
 }
 
-func (c *client) NewHistorySegmentor(sink func(HistorySegment)) HistorySegmentor {
-	return newHistorySegmentor(c, sink)
+func (c *client) NewHistorySegmentor() HistorySegmentor {
+	return NewHistorySegmentor(c)
 }
 
 func (c *client) FindAll(input *FindInput) (output *FindOutput, err error) {

--- a/fsm/client.go
+++ b/fsm/client.go
@@ -27,17 +27,18 @@ type FSMClient interface {
 	Signal(id string, signal string, input interface{}) error
 	Start(startTemplate swf.StartWorkflowExecutionInput, id string, input interface{}) (*swf.StartWorkflowExecutionOutput, error)
 	RequestCancel(id string) error
-	GetHistoryEventIteratorFromWorkflowExecution(execution *swf.WorkflowExecution) (HistoryEventIterator, error)
-	GetHistoryEventIteratorFromReader(reader io.Reader) (HistoryEventIterator, error)
+	GetWorkflowExecutionHistoryPages(execution *swf.WorkflowExecution, fn func(p *swf.GetWorkflowExecutionHistoryOutput, lastPage bool) (shouldContinue bool)) error
+	GetWorkflowExecutionHistoryFromReader(reader io.Reader) (*swf.GetWorkflowExecutionHistoryOutput, error)
 	FindAll(input *FindInput) (output *FindOutput, err error)
 	FindLatestByWorkflowID(workflowID string) (exec *swf.WorkflowExecution, err error)
-	SegmentHistory(itr HistoryEventIterator) ([]HistorySegment, error)
+	NewHistorySegmentor(sink func(HistorySegment)) HistorySegmentor
 }
 
 type ClientSWFOps interface {
 	ListOpenWorkflowExecutions(req *swf.ListOpenWorkflowExecutionsInput) (resp *swf.WorkflowExecutionInfos, err error)
 	ListClosedWorkflowExecutions(req *swf.ListClosedWorkflowExecutionsInput) (resp *swf.WorkflowExecutionInfos, err error)
 	GetWorkflowExecutionHistory(req *swf.GetWorkflowExecutionHistoryInput) (resp *swf.GetWorkflowExecutionHistoryOutput, err error)
+	GetWorkflowExecutionHistoryPages(input *swf.GetWorkflowExecutionHistoryInput, fn func(p *swf.GetWorkflowExecutionHistoryOutput, lastPage bool) (shouldContinue bool)) error
 	SignalWorkflowExecution(req *swf.SignalWorkflowExecutionInput) (resp *swf.SignalWorkflowExecutionOutput, err error)
 	StartWorkflowExecution(req *swf.StartWorkflowExecutionInput) (resp *swf.StartWorkflowExecutionOutput, err error)
 	TerminateWorkflowExecution(req *swf.TerminateWorkflowExecutionInput) (resp *swf.TerminateWorkflowExecutionOutput, err error)
@@ -55,8 +56,6 @@ type client struct {
 	f *FSM
 	c ClientSWFOps
 }
-
-type HistoryEventIterator func() (*swf.HistoryEvent, error)
 
 type WorkflowInfosFunc func(infos *swf.WorkflowExecutionInfos) error
 
@@ -217,39 +216,14 @@ func (c *client) RequestCancel(id string) error {
 	return err
 }
 
-func (c *client) GetHistoryEventIteratorFromWorkflowExecution(execution *swf.WorkflowExecution) (HistoryEventIterator, error) {
+func (c *client) GetWorkflowExecutionHistoryPages(execution *swf.WorkflowExecution, fn func(p *swf.GetWorkflowExecutionHistoryOutput, lastPage bool) (shouldContinue bool)) error {
 	req := &swf.GetWorkflowExecutionHistoryInput{
 		Domain:       S(c.f.Domain),
 		Execution:    execution,
 		ReverseOrder: aws.Bool(true),
 	}
 
-	history, err := c.c.GetWorkflowExecutionHistory(req)
-	if err != nil {
-		return nil, err
-	}
-
-	i := 0
-	return func() (*swf.HistoryEvent, error) {
-		if i < len(history.Events) {
-			e := history.Events[i]
-			i++
-			return e, nil
-		}
-
-		if history.NextPageToken != nil {
-			req.NextPageToken = history.NextPageToken
-			history, err = c.c.GetWorkflowExecutionHistory(req)
-			if err != nil {
-				return nil, err
-			}
-
-			i = 1
-			return history.Events[0], nil
-		}
-
-		return nil, nil
-	}, nil
+	return c.c.GetWorkflowExecutionHistoryPages(req, fn)
 }
 
 type sortHistoryEvents []*swf.HistoryEvent
@@ -258,28 +232,19 @@ func (es sortHistoryEvents) Len() int           { return len(es) }
 func (es sortHistoryEvents) Swap(i, j int)      { es[i], es[j] = es[j], es[i] }
 func (es sortHistoryEvents) Less(i, j int) bool { return *es[i].EventId < *es[j].EventId }
 
-func (c *client) GetHistoryEventIteratorFromReader(reader io.Reader) (HistoryEventIterator, error) {
-	history := swf.GetWorkflowExecutionHistoryOutput{}
-	err := jsonutil.UnmarshalJSON(&history, reader)
+func (c *client) GetWorkflowExecutionHistoryFromReader(reader io.Reader) (*swf.GetWorkflowExecutionHistoryOutput, error) {
+	history := &swf.GetWorkflowExecutionHistoryOutput{}
+	err := jsonutil.UnmarshalJSON(history, reader)
 	if err != nil {
 		return nil, err
 	}
 
 	sort.Sort(sort.Reverse(sortHistoryEvents(history.Events)))
-
-	i := 0
-	return func() (*swf.HistoryEvent, error) {
-		if i < len(history.Events) {
-			e := history.Events[i]
-			i++
-			return e, nil
-		}
-		return nil, nil
-	}, nil
+	return history, nil
 }
 
-func (c *client) SegmentHistory(itr HistoryEventIterator) ([]HistorySegment, error) {
-	return newHistorySegmentor(c).FromHistoryEventIterator(itr)
+func (c *client) NewHistorySegmentor(sink func(HistorySegment)) HistorySegmentor {
+	return newHistorySegmentor(c, sink)
 }
 
 func (c *client) FindAll(input *FindInput) (output *FindOutput, err error) {

--- a/fsm/client_test.go
+++ b/fsm/client_test.go
@@ -130,16 +130,17 @@ func TestClient(t *testing.T) {
 	}
 
 	segments := []HistorySegment{}
-	seg := fsmClient.NewHistorySegmentor(func(segment HistorySegment) {
+	seg := fsmClient.NewHistorySegmentor()
+	seg.OnSegment(func(segment HistorySegment) {
 		segments = append(segments, segment)
+	})
+	seg.OnError(func(err error) {
+		t.Fatal(err)
 	})
 
 	err = fsmClient.GetWorkflowExecutionHistoryPages(exec, seg.FromPage)
 	if err != nil {
 		t.Fatal(err)
-	}
-	if seg.GetError() != nil {
-		t.Fatal(seg.GetError())
 	}
 
 	if length := len(segments); length != 2 {
@@ -557,178 +558,6 @@ func TestFindAll_FindLatestByWorkflowID(t *testing.T) {
 	}
 
 	mockSwf.AssertExpectations(t)
-}
-
-func TestSegmentHistory(t *testing.T) {
-	fsm := dummyFsm()
-
-	var readyData interface{}
-	readyData = TestData{States: []string{"ready data"}}
-
-	var startData interface{}
-	startData = TestData{States: []string{"start data"}}
-
-	activityId := "activity-id"
-	activityData := "activity data"
-
-	errorState := &SerializedErrorState{
-		EarliestUnprocessedEventId: -1,
-		LatestUnprocessedEventId:   -2,
-		ErrorEvent: &swf.HistoryEvent{
-			EventId: aws.Int64(-3),
-		},
-	}
-
-	history := &swf.GetWorkflowExecutionHistoryOutput{Events: []*swf.HistoryEvent{
-		&swf.HistoryEvent{
-			EventId:   aws.Int64(8),
-			EventType: aws.String(swf.EventTypeActivityTaskScheduled),
-			ActivityTaskScheduledEventAttributes: &swf.ActivityTaskScheduledEventAttributes{
-				ActivityId: aws.String(activityId),
-				Input:      aws.String(fsm.Serialize(activityData)),
-				DecisionTaskCompletedEventId: aws.Int64(4),
-			},
-		},
-		&swf.HistoryEvent{
-			EventId:   aws.Int64(7),
-			EventType: aws.String(swf.EventTypeMarkerRecorded),
-			MarkerRecordedEventAttributes: &swf.MarkerRecordedEventAttributes{
-				MarkerName: aws.String(ErrorMarker),
-				Details:    aws.String(fsm.Serialize(errorState)),
-			},
-		},
-		&swf.HistoryEvent{
-			EventId:   aws.Int64(6),
-			EventType: aws.String(swf.EventTypeMarkerRecorded),
-			MarkerRecordedEventAttributes: &swf.MarkerRecordedEventAttributes{
-				MarkerName: aws.String(CorrelatorMarker),
-				Details:    aws.String(fsm.Serialize(EventCorrelator{})),
-			},
-		},
-		&swf.HistoryEvent{
-			EventId:   aws.Int64(5),
-			EventType: aws.String(swf.EventTypeMarkerRecorded),
-			MarkerRecordedEventAttributes: &swf.MarkerRecordedEventAttributes{
-				MarkerName: aws.String(StateMarker),
-				Details: aws.String(fsm.Serialize(SerializedState{
-					StateVersion: 1,
-					StateName:    "ready",
-					StateData:    fsm.Serialize(readyData),
-				})),
-			},
-		},
-		&swf.HistoryEvent{
-			EventId:   aws.Int64(4),
-			EventType: aws.String(swf.EventTypeDecisionTaskCompleted),
-		},
-		&swf.HistoryEvent{
-			EventId:   aws.Int64(3),
-			EventType: aws.String(swf.EventTypeDecisionTaskStarted),
-		},
-		&swf.HistoryEvent{
-			EventId:   aws.Int64(2),
-			EventType: aws.String(swf.EventTypeDecisionTaskScheduled),
-		},
-		&swf.HistoryEvent{
-			EventId:   aws.Int64(1),
-			EventType: aws.String(swf.EventTypeWorkflowExecutionStarted),
-			WorkflowExecutionStartedEventAttributes: &swf.WorkflowExecutionStartedEventAttributes{
-				Input: StartFSMWorkflowInput(fsm, &startData),
-			},
-		},
-	}}
-
-	actual := []HistorySegment{}
-	seg := NewFSMClient(fsm, &mocks.SWFAPI{}).NewHistorySegmentor(func(segment HistorySegment) {
-		actual = append(actual, segment)
-	})
-
-	shouldContinue := seg.FromPage(history, true)
-	if !shouldContinue {
-		t.Error(shouldContinue)
-	}
-	if seg.GetError() != nil {
-		t.Error(seg.GetError())
-	}
-
-	expected := []HistorySegment{
-		HistorySegment{
-			State: &HistorySegmentState{
-				ID:      aws.Int64(999999),
-				Version: uInt64(999999),
-				Name:    aws.String("<unrecorded>"),
-				Data:    nil,
-			},
-			Correlator: nil,
-			Error:      nil,
-			Events: []*HistorySegmentEvent{
-				&HistorySegmentEvent{
-					ID:   aws.Int64(8),
-					Type: aws.String(swf.EventTypeActivityTaskScheduled),
-					Attributes: &map[string]interface{}{
-						"ActivityId":                   activityId,
-						"ActivityType":                 nil,
-						"Control":                      nil,
-						"DecisionTaskCompletedEventId": 4,
-						"HeartbeatTimeout":             nil,
-						"Input":                        fsm.Serialize(activityData), // TODO: un-double escape?
-						"ScheduleToCloseTimeout":       nil,
-						"ScheduleToStartTimeout":       nil,
-						"StartToCloseTimeout":          nil,
-						"TaskList":                     nil,
-						"TaskPriority":                 nil,
-					},
-				},
-			},
-		},
-		HistorySegment{
-			State: &HistorySegmentState{
-				ID:      aws.Int64(5),
-				Version: uInt64(1),
-				Name:    aws.String("ready"),
-				Data:    &readyData,
-			},
-			Correlator: &EventCorrelator{},
-			Error:      errorState,
-			Events: []*HistorySegmentEvent{
-				&HistorySegmentEvent{
-					ID:         aws.Int64(4),
-					Type:       aws.String(swf.EventTypeDecisionTaskCompleted),
-					References: []*int64{aws.Int64(8)},
-				},
-				&HistorySegmentEvent{
-					ID:   aws.Int64(3),
-					Type: aws.String(swf.EventTypeDecisionTaskStarted),
-				},
-				&HistorySegmentEvent{
-					ID:   aws.Int64(2),
-					Type: aws.String(swf.EventTypeDecisionTaskScheduled),
-				},
-			},
-		},
-		HistorySegment{
-			State: &HistorySegmentState{
-				ID:      aws.Int64(1),
-				Version: uInt64(0),
-				Name:    aws.String("initial"),
-				Data:    &startData,
-			},
-			Correlator: nil,
-			Events:     []*HistorySegmentEvent{},
-		},
-	}
-
-	for i, e := range expected {
-		a := actual[i]
-		if fsm.Serialize(e) != fsm.Serialize(a) {
-			t.Logf("expected[%d]:\n%#v\n\n actual[%d]:\n%#v", i, fsm.Serialize(e), i, fsm.Serialize(a))
-			t.FailNow()
-		}
-	}
-}
-
-func uInt64(v uint64) *uint64 {
-	return &v
 }
 
 func dummyFsm() *FSM {

--- a/fsm/history_segments.go
+++ b/fsm/history_segments.go
@@ -44,6 +44,7 @@ type HistorySegmentor interface {
 	FromPage(p *swf.GetWorkflowExecutionHistoryOutput, lastPage bool) (shouldContinue bool)
 	OnStart(fn func()) HistorySegmentor
 	OnSegment(func(HistorySegment)) HistorySegmentor
+	OnPage(fn func()) HistorySegmentor
 	OnError(func(error)) HistorySegmentor
 	OnFinish(fn func()) HistorySegmentor
 }
@@ -52,6 +53,7 @@ type historySegmentor struct {
 	c         *client
 	onStart   func()
 	onSegment func(HistorySegment)
+	onPage    func()
 	onError   func(error)
 	onFinish  func()
 
@@ -68,6 +70,7 @@ func NewHistorySegmentor(c *client) *historySegmentor {
 		c:         c,
 		onStart:   func() {},
 		onSegment: func(_ HistorySegment) {},
+		onPage:    func() {},
 		onError:   func(_ error) {},
 		onFinish:  func() {},
 		segment:   HistorySegment{Events: []*HistorySegmentEvent{}},
@@ -82,6 +85,11 @@ func (s *historySegmentor) OnStart(fn func()) HistorySegmentor {
 
 func (s *historySegmentor) OnSegment(fn func(HistorySegment)) HistorySegmentor {
 	s.onSegment = fn
+	return s
+}
+
+func (s *historySegmentor) OnPage(fn func()) HistorySegmentor {
+	s.onPage = fn
 	return s
 }
 
@@ -107,6 +115,7 @@ func (s *historySegmentor) FromPage(p *swf.GetWorkflowExecutionHistoryOutput, la
 		s.finish()
 	}
 
+	s.onPage()
 	return true
 }
 

--- a/fsm/history_segments_test.go
+++ b/fsm/history_segments_test.go
@@ -1,0 +1,182 @@
+package fsm
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/swf"
+	"github.com/sclasen/swfsm/testing/mocks"
+)
+
+func TestSegmentHistory(t *testing.T) {
+	fsm := dummyFsm()
+
+	var readyData interface{}
+	readyData = TestData{States: []string{"ready data"}}
+
+	var startData interface{}
+	startData = TestData{States: []string{"start data"}}
+
+	activityId := "activity-id"
+	activityData := "activity data"
+
+	errorState := &SerializedErrorState{
+		EarliestUnprocessedEventId: -1,
+		LatestUnprocessedEventId:   -2,
+		ErrorEvent: &swf.HistoryEvent{
+			EventId: aws.Int64(-3),
+		},
+	}
+
+	history := &swf.GetWorkflowExecutionHistoryOutput{Events: []*swf.HistoryEvent{
+		&swf.HistoryEvent{
+			EventId:   aws.Int64(8),
+			EventType: aws.String(swf.EventTypeActivityTaskScheduled),
+			ActivityTaskScheduledEventAttributes: &swf.ActivityTaskScheduledEventAttributes{
+				ActivityId: aws.String(activityId),
+				Input:      aws.String(fsm.Serialize(activityData)),
+				DecisionTaskCompletedEventId: aws.Int64(4),
+			},
+		},
+		&swf.HistoryEvent{
+			EventId:   aws.Int64(7),
+			EventType: aws.String(swf.EventTypeMarkerRecorded),
+			MarkerRecordedEventAttributes: &swf.MarkerRecordedEventAttributes{
+				MarkerName: aws.String(ErrorMarker),
+				Details:    aws.String(fsm.Serialize(errorState)),
+			},
+		},
+		&swf.HistoryEvent{
+			EventId:   aws.Int64(6),
+			EventType: aws.String(swf.EventTypeMarkerRecorded),
+			MarkerRecordedEventAttributes: &swf.MarkerRecordedEventAttributes{
+				MarkerName: aws.String(CorrelatorMarker),
+				Details:    aws.String(fsm.Serialize(EventCorrelator{})),
+			},
+		},
+		&swf.HistoryEvent{
+			EventId:   aws.Int64(5),
+			EventType: aws.String(swf.EventTypeMarkerRecorded),
+			MarkerRecordedEventAttributes: &swf.MarkerRecordedEventAttributes{
+				MarkerName: aws.String(StateMarker),
+				Details: aws.String(fsm.Serialize(SerializedState{
+					StateVersion: 1,
+					StateName:    "ready",
+					StateData:    fsm.Serialize(readyData),
+				})),
+			},
+		},
+		&swf.HistoryEvent{
+			EventId:   aws.Int64(4),
+			EventType: aws.String(swf.EventTypeDecisionTaskCompleted),
+		},
+		&swf.HistoryEvent{
+			EventId:   aws.Int64(3),
+			EventType: aws.String(swf.EventTypeDecisionTaskStarted),
+		},
+		&swf.HistoryEvent{
+			EventId:   aws.Int64(2),
+			EventType: aws.String(swf.EventTypeDecisionTaskScheduled),
+		},
+		&swf.HistoryEvent{
+			EventId:   aws.Int64(1),
+			EventType: aws.String(swf.EventTypeWorkflowExecutionStarted),
+			WorkflowExecutionStartedEventAttributes: &swf.WorkflowExecutionStartedEventAttributes{
+				Input: StartFSMWorkflowInput(fsm, &startData),
+			},
+		},
+	}}
+
+	actual := []HistorySegment{}
+	seg := NewFSMClient(fsm, &mocks.SWFAPI{}).NewHistorySegmentor()
+	seg.OnSegment(func(segment HistorySegment) {
+		actual = append(actual, segment)
+	})
+	seg.OnError(func(err error) {
+		t.Error(err)
+	})
+
+	shouldContinue := seg.FromPage(history, true)
+	if !shouldContinue {
+		t.Error(shouldContinue)
+	}
+
+	expected := []HistorySegment{
+		HistorySegment{
+			State: &HistorySegmentState{
+				ID:      aws.Int64(999999),
+				Version: uInt64(999999),
+				Name:    aws.String("<unrecorded>"),
+				Data:    nil,
+			},
+			Correlator: nil,
+			Error:      nil,
+			Events: []*HistorySegmentEvent{
+				&HistorySegmentEvent{
+					ID:   aws.Int64(8),
+					Type: aws.String(swf.EventTypeActivityTaskScheduled),
+					Attributes: &map[string]interface{}{
+						"ActivityId":                   activityId,
+						"ActivityType":                 nil,
+						"Control":                      nil,
+						"DecisionTaskCompletedEventId": 4,
+						"HeartbeatTimeout":             nil,
+						"Input":                        fsm.Serialize(activityData), // TODO: un-double escape?
+						"ScheduleToCloseTimeout":       nil,
+						"ScheduleToStartTimeout":       nil,
+						"StartToCloseTimeout":          nil,
+						"TaskList":                     nil,
+						"TaskPriority":                 nil,
+					},
+				},
+			},
+		},
+		HistorySegment{
+			State: &HistorySegmentState{
+				ID:      aws.Int64(5),
+				Version: uInt64(1),
+				Name:    aws.String("ready"),
+				Data:    &readyData,
+			},
+			Correlator: &EventCorrelator{},
+			Error:      errorState,
+			Events: []*HistorySegmentEvent{
+				&HistorySegmentEvent{
+					ID:         aws.Int64(4),
+					Type:       aws.String(swf.EventTypeDecisionTaskCompleted),
+					References: []*int64{aws.Int64(8)},
+				},
+				&HistorySegmentEvent{
+					ID:   aws.Int64(3),
+					Type: aws.String(swf.EventTypeDecisionTaskStarted),
+				},
+				&HistorySegmentEvent{
+					ID:   aws.Int64(2),
+					Type: aws.String(swf.EventTypeDecisionTaskScheduled),
+				},
+			},
+		},
+		HistorySegment{
+			State: &HistorySegmentState{
+				ID:      aws.Int64(1),
+				Version: uInt64(0),
+				Name:    aws.String("initial"),
+				Data:    &startData,
+			},
+			Correlator: nil,
+			Events:     []*HistorySegmentEvent{},
+		},
+	}
+
+	for i, e := range expected {
+		a := actual[i]
+		if fsm.Serialize(e) != fsm.Serialize(a) {
+			t.Logf("expected[%d]:\n%#v\n\n actual[%d]:\n%#v", i, fsm.Serialize(e), i, fsm.Serialize(a))
+			t.FailNow()
+		}
+	}
+}
+
+func uInt64(v uint64) *uint64 {
+	return &v
+}


### PR DESCRIPTION
This replaces the custom `HistoryEventIterator` with use of the `GetWorkflowExecutionHistoryPages` that already exists in the SWF client. The `HistorySegmentor` is updated to support this and now has callbacks for listening for events during the paging.