### PR TITLE
make fsm.Finder public

### DIFF
--- a/fsm/client.go
+++ b/fsm/client.go
@@ -252,5 +252,9 @@ func (c *client) FindAll(input *FindInput) (output *FindOutput, err error) {
 }
 
 func (c *client) FindLatestByWorkflowID(workflowID string) (exec *swf.WorkflowExecution, err error) {
-	return NewFinder(c.f.Domain, c.c).FindLatestByWorkflowID(workflowID)
+	ex, err := NewFinder(c.f.Domain, c.c).FindLatestByWorkflowID(workflowID)
+	if err == nil && ex == nil {
+		return nil, errors.Trace(fmt.Errorf("workflow not found for id %s", workflowID))
+	}
+	return ex, err
 }

--- a/fsm/client.go
+++ b/fsm/client.go
@@ -248,9 +248,9 @@ func (c *client) NewHistorySegmentor() HistorySegmentor {
 }
 
 func (c *client) FindAll(input *FindInput) (output *FindOutput, err error) {
-	return newFinder(c).FindAll(input)
+	return NewFinder(c.f.Domain, c.c).FindAll(input)
 }
 
 func (c *client) FindLatestByWorkflowID(workflowID string) (exec *swf.WorkflowExecution, err error) {
-	return newFinder(c).FindLatestByWorkflowID(workflowID)
+	return NewFinder(c.f.Domain, c.c).FindLatestByWorkflowID(workflowID)
 }

--- a/fsm/finder.go
+++ b/fsm/finder.go
@@ -8,7 +8,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/swf"
-	"github.com/juju/errors"
 	. "github.com/sclasen/swfsm/log"
 	. "github.com/sclasen/swfsm/sugar"
 )
@@ -290,7 +289,6 @@ func (f *finder) FindLatestByWorkflowID(workflowID string) (exec *swf.WorkflowEx
 
 	if len(output.ExecutionInfos) == 1 {
 		return output.ExecutionInfos[0].Execution, nil
-	} else {
-		return nil, errors.Trace(fmt.Errorf("workflow not found for id %s", workflowID))
 	}
+	return nil, nil
 }


### PR DESCRIPTION
... and usable without a `fsm.FSMClient`. Tests in `fsm/client_test.go` still cover all the functionality exposed by `fsm.Finder`.

/cc @ryanbrainard 