### PR TITLE
Update example to use StartFSMWorkflowInput

### DIFF
--- a/fsm/fsm_test.go
+++ b/fsm/fsm_test.go
@@ -488,7 +488,7 @@ func ExampleFSM() {
 		WorkflowId: S("your-id"),
 		//you will have previously regiestered a WorkflowType that this FSM will work.
 		WorkflowType: &swf.WorkflowType{Name: S("the-name"), Version: S("the-version")},
-		Input:        S(fsm.Serialize(&StateData{Count: 0, Message: "starting message"})),
+		Input:        StartFSMWorkflowInput(fsm, &StateData{Count: 0, Message: "starting message"}),
 	})
 }
 


### PR DESCRIPTION
Fixes #111 

Users get deserialization errors if they don't setup the input correctly.