### PR TITLE
countdown dispatcher

### DIFF
--- a/activity/dispatchers.go
+++ b/activity/dispatchers.go
@@ -81,7 +81,7 @@ func countdownDispatcherName() string {
 	return fmt.Sprintf("countdown-%d", seq)
 }
 
-//construct a new CountdownGoroutineDispatcher, start it and register it with the given ShutdownManager
+//RegisterNewCountdownGoroutineDispatcher constructs a new CountdownGoroutineDispatcher, start it and register it with the given ShutdownManager
 func RegisterNewCountdownGoroutineDispatcher(mgr poller.ShutdownManager) *CountdownGoroutineDispatcher {
 	g := &CountdownGoroutineDispatcher{
 		Stop:    make(chan bool, 1),

--- a/activity/dispatchers_test.go
+++ b/activity/dispatchers_test.go
@@ -20,6 +20,22 @@ func TestBoundedGoroutineDispatcher(t *testing.T) {
 	testDispatcher(&BoundedGoroutineDispatcher{NumGoroutines: 8}, t)
 }
 
+func TestCountdownGoroutineDispatcher(t *testing.T) {
+	dispatcher := &CountdownGoroutineDispatcher{
+		Stop:    make(chan bool, 1),
+		StopAck: make(chan bool, 1),
+	}
+	go dispatcher.Start()
+	testDispatcher(dispatcher, t)
+	dispatcher.Stop <- true
+
+	select {
+	case <-dispatcher.Stop:
+	case <-time.After(1 * time.Second):
+		t.Fatal("timed out waiting for tasks to countdown")
+	}
+}
+
 func testDispatcher(dispatcher ActivityTaskDispatcher, t *testing.T) {
 	task := &swf.PollForActivityTaskOutput{}
 	tasksHandled := int32(0)

--- a/activity/dispatchers_test.go
+++ b/activity/dispatchers_test.go
@@ -25,10 +25,13 @@ func TestCountdownGoroutineDispatcher(t *testing.T) {
 		Stop:    make(chan bool, 1),
 		StopAck: make(chan bool, 1),
 	}
-	go dispatcher.Start()
-	dispatcher.Stop <- true
 
-	testDispatcher(dispatcher, t)
+	go dispatcher.Start()
+
+	go func() {
+		testDispatcher(dispatcher, t)
+		dispatcher.Stop <- true
+	}()
 
 	select {
 	case <-dispatcher.StopAck:

--- a/activity/dispatchers_test.go
+++ b/activity/dispatchers_test.go
@@ -26,11 +26,12 @@ func TestCountdownGoroutineDispatcher(t *testing.T) {
 		StopAck: make(chan bool, 1),
 	}
 	go dispatcher.Start()
-	testDispatcher(dispatcher, t)
 	dispatcher.Stop <- true
 
+	testDispatcher(dispatcher, t)
+
 	select {
-	case <-dispatcher.Stop:
+	case <-dispatcher.StopAck:
 	case <-time.After(1 * time.Second):
 		t.Fatal("timed out waiting for tasks to countdown")
 	}


### PR DESCRIPTION
Register this dispatcher with a ShutdownManager. 

Used in your ActivityWorkers, it will count in-flight activities.

It doesnt ack shutdowns until the number of in flight activities are zero.