### PR TITLE
Out of order replication

### DIFF
--- a/fsm/dispatchers_test.go
+++ b/fsm/dispatchers_test.go
@@ -4,6 +4,7 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/swf"
 
 	"time"
@@ -19,9 +20,19 @@ func TestNewGoroutineDispatcher(t *testing.T) {
 func TestBoundedGoroutineDispatcher(t *testing.T) {
 	testDispatcher(&BoundedGoroutineDispatcher{NumGoroutines: 8}, t)
 }
+func TestGoroutinePerWorkflowDispatcher(t *testing.T) {
+	testDispatcher(GoroutinePerWorkflowDispatcher(1000), t)
+}
+func TestGoroutinePerWorkflowDispatcherUnbuffered(t *testing.T) {
+	testDispatcher(GoroutinePerWorkflowDispatcher(0), t)
+}
 
 func testDispatcher(dispatcher DecisionTaskDispatcher, t *testing.T) {
-	task := &swf.PollForDecisionTaskOutput{}
+	task := &swf.PollForDecisionTaskOutput{
+		WorkflowExecution: &swf.WorkflowExecution{
+			RunId: aws.String("workflow-dummy"),
+		},
+	}
 	tasksHandled := int32(0)
 	totalTasks := int32(1000)
 	done := make(chan struct{}, 1)

--- a/fsm/fsm.go
+++ b/fsm/fsm.go
@@ -30,7 +30,7 @@ type FSM struct {
 	Identity string
 	// Client used to make SWF api requests.
 	SWF SWFOps
-	// Strategy for replication of state to the systems the build the Query side model.
+	// Strategy for replication of state. Events may be delivered out of order.
 	ReplicationHandler ReplicationHandler
 	// DataType of the data struct associated with this FSM.
 	// The data is automatically peristed to and loaded from workflow history by the FSM.

--- a/fsm/replicators.go
+++ b/fsm/replicators.go
@@ -9,6 +9,7 @@ import (
 )
 
 //ReplicationHandler can be configured on an FSM and will be called when a DecisionTask is successfully completed.
+//Note that events can be delivered out of order to the ReplicationHandler.
 type ReplicationHandler func(*FSMContext, *swf.PollForDecisionTaskOutput, *swf.RespondDecisionTaskCompletedInput, *SerializedState) error
 
 //KinesisOps is the subset of kinesis.Kinesis ops required by KinesisReplication


### PR DESCRIPTION
ReplicationHandlers may receive events out of order.

Document it, and add a new DIspatcher (`GoroutinePerWorkflowDispatcher`) that can be used to guarantee delivery in order within a single decider process (order is still not guaranteed across multiple decider processes).