### PR TITLE
standardize on error=%q

### DIFF
--- a/activity/coordinated_worker.go
+++ b/activity/coordinated_worker.go
@@ -60,7 +60,7 @@ func (c *coordinatedActivityAdapter) heartbeat(activityTask *swf.PollForActivity
 					cancelActivity <- nil
 					return
 				}
-				Log.Printf("workflow-id=%s activity-id=%s activity-id=%s at=heartbeat-error error=%s ", LS(activityTask.WorkflowExecution.WorkflowId), LS(activityTask.ActivityType.Name), LS(activityTask.ActivityId), err.Error())
+				Log.Printf("workflow-id=%s activity-id=%s activity-id=%s at=heartbeat-error error=%q", LS(activityTask.WorkflowExecution.WorkflowId), LS(activityTask.ActivityType.Name), LS(activityTask.ActivityId), err.Error())
 			} else {
 				Log.Printf("workflow-id=%s activity-id=%s activity-id=%s at=heartbeat-recorded", LS(activityTask.WorkflowExecution.WorkflowId), LS(activityTask.ActivityType.Name), LS(activityTask.ActivityId))
 				if *status.CancelRequested {
@@ -87,7 +87,7 @@ func (c *coordinatedActivityAdapter) coordinate(activityTask *swf.PollForActivit
 			update = input
 		}
 		if cerr := c.handler.Cancel(activityTask, update); cerr != nil {
-			Log.Printf("workflow-id=%s activity-id=%s activity-id=%s at=activity-cancel-err err=%q", LS(activityTask.WorkflowExecution.WorkflowId), LS(activityTask.ActivityType.Name), LS(activityTask.ActivityId), cerr)
+			Log.Printf("workflow-id=%s activity-id=%s activity-id=%s at=activity-cancel-err error=%q", LS(activityTask.WorkflowExecution.WorkflowId), LS(activityTask.ActivityType.Name), LS(activityTask.ActivityId), cerr)
 		}
 		return nil, err
 	}
@@ -104,7 +104,7 @@ func (c *coordinatedActivityAdapter) coordinate(activityTask *swf.PollForActivit
 		select {
 		case cause := <-cancel:
 			if err := c.handler.Cancel(activityTask, input); err != nil {
-				Log.Printf("workflow-id=%s activity-id=%s activity-id=%s at=activity-cancel-err err=%q", LS(activityTask.WorkflowExecution.WorkflowId), LS(activityTask.ActivityType.Name), LS(activityTask.ActivityId), err)
+				Log.Printf("workflow-id=%s activity-id=%s activity-id=%s at=activity-cancel-err error=%q", LS(activityTask.WorkflowExecution.WorkflowId), LS(activityTask.ActivityType.Name), LS(activityTask.ActivityId), err)
 			}
 			return nil, cause
 		case <-ticks.C:

--- a/activity/worker.go
+++ b/activity/worker.go
@@ -197,14 +197,14 @@ func (h *ActivityWorker) fail(task *swf.PollForActivityTaskOutput, err error) {
 			}
 		}
 	}
-	Log.Printf("workflow-id=%s activity-id=%s activity-id=%s at=fail error=%s ", LS(task.WorkflowExecution.WorkflowId), LS(task.ActivityType.Name), LS(task.ActivityId), err.Error())
+	Log.Printf("workflow-id=%s activity-id=%s activity-id=%s at=fail error=%q", LS(task.WorkflowExecution.WorkflowId), LS(task.ActivityType.Name), LS(task.ActivityId), err.Error())
 	_, failErr := h.SWF.RespondActivityTaskFailed(&swf.RespondActivityTaskFailedInput{
 		TaskToken: task.TaskToken,
 		Reason:    S(err.Error()),
 		Details:   S(err.Error()),
 	})
 	if failErr != nil {
-		Log.Printf("workflow-id=%s activity-id=%s activity-id=%s at=failed-response-fail error=%s ", LS(task.WorkflowExecution.WorkflowId), LS(task.ActivityType.Name), LS(task.ActivityId), failErr.Error())
+		Log.Printf("workflow-id=%s activity-id=%s activity-id=%s at=failed-response-fail error=%q", LS(task.WorkflowExecution.WorkflowId), LS(task.ActivityType.Name), LS(task.ActivityId), failErr.Error())
 	}
 }
 
@@ -265,7 +265,7 @@ func (h *ActivityWorker) done(resp *swf.PollForActivityTaskOutput, result *strin
 		Result:    result,
 	})
 	if completeErr != nil {
-		Log.Printf("workflow-id=%s activity-id=%s activity-id=%s at=completed-response-fail error=%s ", LS(resp.WorkflowExecution.WorkflowId), LS(resp.ActivityType.Name), LS(resp.ActivityId), completeErr.Error())
+		Log.Printf("workflow-id=%s activity-id=%s activity-id=%s at=completed-response-fail error=%q", LS(resp.WorkflowExecution.WorkflowId), LS(resp.ActivityType.Name), LS(resp.ActivityId), completeErr.Error())
 	}
 }
 
@@ -277,7 +277,7 @@ func (h *ActivityWorker) canceled(resp *swf.PollForActivityTaskOutput, details *
 		Details:   details,
 	})
 	if canceledErr != nil {
-		Log.Printf("workflow-id=%s activity-id=%s activity-id=%s at=canceled-response-fail error=%s ", LS(resp.WorkflowExecution.WorkflowId), LS(resp.ActivityType.Name), LS(resp.ActivityId), canceledErr.Error())
+		Log.Printf("workflow-id=%s activity-id=%s activity-id=%s at=canceled-response-fail error=%q", LS(resp.WorkflowExecution.WorkflowId), LS(resp.ActivityType.Name), LS(resp.ActivityId), canceledErr.Error())
 	}
 }
 
@@ -291,7 +291,7 @@ func (h *ActivityWorker) handleWithRecovery(handler func(*swf.PollForActivityTas
 				} else {
 					anErr = errors.New("panic in activity with nil error")
 				}
-				Log.Printf("component=activity at=error error=activity-panic-recovery msg=%s", r)
+				Log.Printf("component=activity at=activity-panic-recovery-error error=%q", r)
 				h.fail(resp, anErr)
 			}
 		}()

--- a/fsm/client.go
+++ b/fsm/client.go
@@ -124,7 +124,7 @@ func (c *client) GetSerializedStateForRun(id, run string) (*SerializedState, *sw
 			if ae, ok := err.(awserr.Error); ok {
 				Log.Printf("component=client fn=GetState at=get-history error-type=%s message=%s", ae.Code(), ae.Message())
 			} else {
-				Log.Printf("component=client fn=GetState at=get-history error=%s", err)
+				Log.Printf("component=client fn=GetState at=get-history error=%q", err)
 			}
 			return nil, nil, err
 		}
@@ -150,13 +150,13 @@ func (c *client) GetSerializedStateForRun(id, run string) (*SerializedState, *sw
 func (c *client) GetStateForRun(id, run string) (string, interface{}, error) {
 	serialized, _, err := c.GetSerializedStateForRun(id, run)
 	if err != nil {
-		Log.Printf("component=client fn=GetState at=get-serialized-state error=%s", err)
+		Log.Printf("component=client fn=GetState at=get-serialized-state error=%q", err)
 		return "", nil, err
 	}
 	data := c.f.zeroStateData()
 	err = c.f.Serializer.Deserialize(serialized.StateData, data)
 	if err != nil {
-		Log.Printf("component=client fn=GetState at=deserialize-serialized-state error=%s", err)
+		Log.Printf("component=client fn=GetState at=deserialize-serialized-state error=%q", err)
 		return "", nil, err
 	}
 

--- a/fsm/finder.go
+++ b/fsm/finder.go
@@ -282,7 +282,7 @@ func (f *finder) FindLatestByWorkflowID(workflowID string) (exec *swf.WorkflowEx
 		if ae, ok := err.(awserr.Error); ok {
 			Log.Printf("component=client fn=findExecution at=list-open error-type=%s message=%s", ae.Code(), ae.Message())
 		} else {
-			Log.Printf("component=client fn=findExecution at=list-open error=%s", err)
+			Log.Printf("component=client fn=findExecution at=list-open error=%q", err)
 		}
 		return nil, err
 	}

--- a/fsm/fsm.go
+++ b/fsm/fsm.go
@@ -162,33 +162,33 @@ func (f *FSM) DefaultCanceledState() *FSMState {
 
 // DefaultDecisionErrorHandler is the DefaultDecisionErrorHandler
 func (f *FSM) DefaultDecisionErrorHandler(ctx *FSMContext, event *swf.HistoryEvent, stateBeforeEvent interface{}, stateAfterError interface{}, err error) (*Outcome, error) {
-	f.log("action=tick workflow=%s workflow-id=%s at=decider-error err=%q", s.LS(ctx.WorkflowType.Name), s.LS(ctx.WorkflowId), err)
+	f.log("action=tick workflow=%s workflow-id=%s at=decider-error error=%q", s.LS(ctx.WorkflowType.Name), s.LS(ctx.WorkflowId), err)
 	return nil, err
 }
 
 // ErrorFindingStateData is part of the FSM implementation of FSMErrorReporter
 func (f *FSM) ErrorFindingStateData(decisionTask *swf.PollForDecisionTaskOutput, err error) {
-	f.log("action=tick workflow=%s workflow-id=%s at=error=find-serialized-state-failed err=%q", s.LS(decisionTask.WorkflowType.Name), s.LS(decisionTask.WorkflowExecution.WorkflowId), err)
+	f.log("action=tick workflow=%s workflow-id=%s at=find-serialized-state-failed error=%q", s.LS(decisionTask.WorkflowType.Name), s.LS(decisionTask.WorkflowExecution.WorkflowId), err)
 }
 
 // ErrorFindingCorrelator is part of the FSM implementation of FSMErrorReporter
 func (f *FSM) ErrorFindingCorrelator(decisionTask *swf.PollForDecisionTaskOutput, err error) {
-	f.log("action=tick workflow=%s workflow-id=%s at=error=find-serialized-event-correlator-failed err=%q", s.LS(decisionTask.WorkflowType.Name), s.LS(decisionTask.WorkflowExecution.WorkflowId), err)
+	f.log("action=tick workflow=%s workflow-id=%s at=find-serialized-event-correlator-failed error=%q", s.LS(decisionTask.WorkflowType.Name), s.LS(decisionTask.WorkflowExecution.WorkflowId), err)
 }
 
 // ErrorMissingFSMState is part of the FSM implementation of FSMErrorReporter
 func (f *FSM) ErrorMissingFSMState(decisionTask *swf.PollForDecisionTaskOutput, outcome Outcome) {
-	f.log("action=tick workflow=%s workflow-id=%s at=error error=marked-state-not-in-fsm state=%s", s.LS(decisionTask.WorkflowType.Name), s.LS(decisionTask.WorkflowExecution.WorkflowId), outcome.State)
+	f.log("action=tick workflow=%s workflow-id=%s at=missing-fsm-state error=marked-state-not-in-fsm state=%s", s.LS(decisionTask.WorkflowType.Name), s.LS(decisionTask.WorkflowExecution.WorkflowId), outcome.State)
 }
 
 // ErrorDeserializingStateData is part of the FSM implementation of FSMErrorReporter
 func (f *FSM) ErrorDeserializingStateData(decisionTask *swf.PollForDecisionTaskOutput, serializedStateData string, err error) {
-	f.log("action=tick workflow=%s workflow-id=%s at=error=deserialize-state-failed err=&s", s.LS(decisionTask.WorkflowType.Name), s.LS(decisionTask.WorkflowExecution.WorkflowId), err)
+	f.log("action=tick workflow=%s workflow-id=%s at=deserialize-state-failed error=%q", s.LS(decisionTask.WorkflowType.Name), s.LS(decisionTask.WorkflowExecution.WorkflowId), err)
 }
 
 // ErrorSerializingStateData is part of the FSM implementation of FSMErrorReporter
 func (f *FSM) ErrorSerializingStateData(decisionTask *swf.PollForDecisionTaskOutput, outcome Outcome, eventCorrelator EventCorrelator, err error) {
-	f.log("action=tick workflow=%s workflow-id=%s at=error error=state-serialization-error err=%q error-type=system", s.LS(decisionTask.WorkflowType.Name), s.LS(decisionTask.WorkflowExecution.WorkflowId), err)
+	f.log("action=tick workflow=%s workflow-id=%s at=state-serialization-error error=%q error-type=system", s.LS(decisionTask.WorkflowType.Name), s.LS(decisionTask.WorkflowExecution.WorkflowId), err)
 
 }
 
@@ -401,7 +401,7 @@ func (f *FSM) Tick(decisionTask *swf.PollForDecisionTaskOutput) (*FSMContext, []
 		if recovery != nil {
 			outcome = recovery
 		} else {
-			logf(context, "at=error error=error-recovery-failed cause=%s", err)
+			logf(context, "at=error-recovery-failed error=%q", err)
 			//bump the unprocessed window, and re-record the error marker
 			errorState.LatestUnprocessedEventId = *decisionTask.StartedEventId
 			final, serializedState, err := f.recordStateMarkers(context, outcome, eventCorrelator, errorState)
@@ -557,7 +557,7 @@ func (f *FSM) panicSafeDecide(state *FSMState, context *FSMContext, event *swf.H
 	defer func() {
 		if !f.AllowPanics {
 			if r := recover(); r != nil {
-				f.log("at=error error=decide-panic-recovery %v", r)
+				f.log("at=decide-panic-recovery error=%q", r)
 				if err, ok := r.(error); ok && err != nil {
 					anErr = errors.Trace(err)
 				} else {

--- a/migrator/migrator.go
+++ b/migrator/migrator.go
@@ -140,7 +140,7 @@ func (d *DomainMigrator) register(rd swf.RegisterDomainInput) {
 func (d *DomainMigrator) isDeprecated(domain *string) bool {
 	desc, err := d.describe(domain)
 	if err != nil {
-		Log.Printf("action=migrate at=is-dep domain=%s error=%s", LS(domain), err.Error())
+		Log.Printf("action=migrate at=is-dep domain=%s error=%q", LS(domain), err.Error())
 		return false
 	}
 
@@ -217,7 +217,7 @@ func (w *WorkflowTypeMigrator) register(rd swf.RegisterWorkflowTypeInput) {
 func (w *WorkflowTypeMigrator) isDeprecated(domain *string, name *string, version *string) bool {
 	desc, err := w.describe(domain, name, version)
 	if err != nil {
-		Log.Printf("action=migrate at=is-dep domain=%s workflow=%s version=%s error=%s", LS(domain), LS(name), LS(version), err.Error())
+		Log.Printf("action=migrate at=is-dep domain=%s workflow=%s version=%s error=%q", LS(domain), LS(name), LS(version), err.Error())
 		return false
 	}
 
@@ -294,7 +294,7 @@ func (a *ActivityTypeMigrator) register(rd swf.RegisterActivityTypeInput) {
 func (a *ActivityTypeMigrator) isDeprecated(domain *string, name *string, version *string) bool {
 	desc, err := a.describe(domain, name, version)
 	if err != nil {
-		Log.Printf("action=migrate at=is-dep domain=%s activity=%s version=%s error=%s", LS(domain), LS(name), LS(version), err.Error())
+		Log.Printf("action=migrate at=is-dep domain=%s activity=%s version=%s error=%q", LS(domain), LS(name), LS(version), err.Error())
 		return false
 	}
 
@@ -376,7 +376,7 @@ func (s *StreamMigrator) awaitActive(stream *string, atMostSeconds int) {
 			StreamName: stream,
 		})
 		if err != nil {
-			Log.Printf("component=kinesis-migrator fn=awaitActive at=describe-error error=%s", err)
+			Log.Printf("component=kinesis-migrator fn=awaitActive at=describe-error error=%q", err)
 			panicWithError(err)
 		}
 		Log.Printf("component=kinesis-migrator fn=awaitActive stream=%s at=describe status=%s", *stream, *desc.StreamDescription.StreamStatus)

--- a/poller/poller.go
+++ b/poller/poller.go
@@ -90,7 +90,7 @@ func (p *DecisionTaskPoller) Poll(taskReady func(*swf.PollForDecisionTaskOutput)
 	}, eachPage)
 
 	if err != nil {
-		Log.Printf("component=DecisionTaskPoller poll-id=%q task-list=%q at=error error=%s",
+		Log.Printf("component=DecisionTaskPoller poll-id=%q task-list=%q at=error error=%q",
 			pollId, p.TaskList, err.Error())
 		return nil, errors.Trace(err)
 	}
@@ -167,7 +167,7 @@ func (p *ActivityTaskPoller) Poll() (*swf.PollForActivityTaskOutput, error) {
 		TaskList: &swf.TaskList{Name: aws.String(p.TaskList)},
 	})
 	if err != nil {
-		Log.Printf("component=ActivityTaskPoller at=error error=%s", err.Error())
+		Log.Printf("component=ActivityTaskPoller at=error error=%q", err.Error())
 		return nil, errors.Trace(err)
 	}
 	if resp.TaskToken != nil {


### PR DESCRIPTION
Many errors have spaces, such as this:

```
error=handler: Throttling: Rate exceeded
```