### PR TITLE
Expose activity handler so users can poll independently.

### DIFF
--- a/activity/coordinated_worker_test.go
+++ b/activity/coordinated_worker_test.go
@@ -32,7 +32,7 @@ func TestCoordinatedActivityHandler(t *testing.T) {
 	worker.AddCoordinatedHandler(1*time.Second, 1*time.Millisecond, handler)
 	worker.Init()
 	input, _ := worker.Serializer.Serialize(&TestInput{Name: "Foo"})
-	worker.handleActivityTask(&swf.PollForActivityTaskOutput{
+	worker.HandleActivityTask(&swf.PollForActivityTaskOutput{
 		TaskToken:         S("token"),
 		WorkflowExecution: &swf.WorkflowExecution{},
 		ActivityType: &swf.ActivityType{
@@ -54,7 +54,7 @@ func TestCoordinatedActivityHandler(t *testing.T) {
 	mockSwf.Completed = nil
 	mockSwf.Canceled = true
 
-	worker.handleActivityTask(&swf.PollForActivityTaskOutput{
+	worker.HandleActivityTask(&swf.PollForActivityTaskOutput{
 		TaskToken:         S("token"),
 		WorkflowExecution: &swf.WorkflowExecution{},
 		ActivityType: &swf.ActivityType{
@@ -88,7 +88,7 @@ func TestTypedCoordinatedActivityHandler(t *testing.T) {
 	worker.AddCoordinatedHandler(1*time.Second, 1*time.Millisecond, handler)
 	worker.Init()
 	input, _ := worker.Serializer.Serialize(&TestInput{Name: "Foo"})
-	worker.handleActivityTask(&swf.PollForActivityTaskOutput{
+	worker.HandleActivityTask(&swf.PollForActivityTaskOutput{
 		TaskToken:         S("token"),
 		WorkflowExecution: &swf.WorkflowExecution{},
 		ActivityType: &swf.ActivityType{
@@ -110,7 +110,7 @@ func TestTypedCoordinatedActivityHandler(t *testing.T) {
 	mockSwf.Completed = nil
 	mockSwf.Canceled = true
 
-	worker.handleActivityTask(&swf.PollForActivityTaskOutput{
+	worker.HandleActivityTask(&swf.PollForActivityTaskOutput{
 		TaskToken:         S("token"),
 		WorkflowExecution: &swf.WorkflowExecution{},
 		ActivityType: &swf.ActivityType{
@@ -151,7 +151,7 @@ func TestTickRateLimit(t *testing.T) {
 	worker.AddCoordinatedHandler(1*time.Second, 100*time.Millisecond, handler)
 	worker.Init()
 	input, _ := worker.Serializer.Serialize(&TestInput{Name: "Foo"})
-	go worker.handleActivityTask(&swf.PollForActivityTaskOutput{
+	go worker.HandleActivityTask(&swf.PollForActivityTaskOutput{
 		TaskToken:         S("token"),
 		WorkflowExecution: &swf.WorkflowExecution{},
 		ActivityType: &swf.ActivityType{

--- a/activity/interceptors_test.go
+++ b/activity/interceptors_test.go
@@ -50,7 +50,7 @@ func TestInterceptors(t *testing.T) {
 
 	worker.AddHandler(handler)
 
-	worker.handleActivityTask(task)
+	worker.HandleActivityTask(task)
 
 	if !calledBefore {
 		t.Fatal("no before")
@@ -66,7 +66,7 @@ func TestInterceptors(t *testing.T) {
 	calledBefore = false
 	calledComplete = false
 
-	worker.handleActivityTask(task)
+	worker.HandleActivityTask(task)
 
 	if !calledBefore {
 		t.Fatal("no before")
@@ -118,7 +118,7 @@ func TestFailedInterceptor(t *testing.T) {
 	}
 
 	worker.AddHandler(handler)
-	worker.handleActivityTask(task)
+	worker.HandleActivityTask(task)
 	if !calledBefore {
 		t.Fatal("no before")
 	}
@@ -171,7 +171,7 @@ func TestCanceledInterceptor(t *testing.T) {
 	}
 
 	worker.AddHandler(handler)
-	worker.handleActivityTask(task)
+	worker.HandleActivityTask(task)
 	if !calledBefore {
 		t.Fatal("no before")
 	}

--- a/activity/worker.go
+++ b/activity/worker.go
@@ -108,7 +108,7 @@ func (a *ActivityWorker) dispatchTask(activityTask *swf.PollForActivityTaskOutpu
 	if a.AllowPanics {
 		a.ActivityTaskDispatcher.DispatchTask(activityTask, a.HandleActivityTask)
 	} else {
-		a.ActivityTaskDispatcher.DispatchTask(activityTask, a.handleWithRecovery(a.HandleActivityTask))
+		a.ActivityTaskDispatcher.DispatchTask(activityTask, a.HandleWithRecovery(a.HandleActivityTask))
 	}
 }
 
@@ -116,9 +116,10 @@ func (a *ActivityWorker) dispatchTask(activityTask *swf.PollForActivityTaskOutpu
 // It is exposed so that users can handle polling themselves and call DispatchTask directly
 // with this as the callback.
 //
-// e.g.  activityWorker.ActivityTaskDispatcher.DispatchTask(activityTask, a.HandleActivityTask)
+// e.g.  activityWorker.ActivityTaskDispatcher.DispatchTask(activityTask, a.HandleWithRecovery(a.HandleActivityTask))
 //
-// Note: You will need to handle recovering from panics if you call this directly.
+// Note: You will need to handle recovering from panics if you call this directly without wrapping
+// with HandleWithRecovery.
 func (a *ActivityWorker) HandleActivityTask(activityTask *swf.PollForActivityTaskOutput) {
 	a.ActivityInterceptor.BeforeTask(activityTask)
 	handler := a.handlers[*activityTask.ActivityType.Name]
@@ -288,7 +289,9 @@ func (h *ActivityWorker) canceled(resp *swf.PollForActivityTaskOutput, details *
 	}
 }
 
-func (h *ActivityWorker) handleWithRecovery(handler func(*swf.PollForActivityTaskOutput)) func(*swf.PollForActivityTaskOutput) {
+// HandleWithRecovery is used to wrap handler functions (such as HandleActivityTask)
+// so they gracefully recover from panics.
+func (h *ActivityWorker) HandleWithRecovery(handler func(*swf.PollForActivityTaskOutput)) func(*swf.PollForActivityTaskOutput) {
 	return func(resp *swf.PollForActivityTaskOutput) {
 		defer func() {
 			var anErr error

--- a/activity/worker.go
+++ b/activity/worker.go
@@ -106,13 +106,20 @@ func (a *ActivityWorker) Start() {
 
 func (a *ActivityWorker) dispatchTask(activityTask *swf.PollForActivityTaskOutput) {
 	if a.AllowPanics {
-		a.ActivityTaskDispatcher.DispatchTask(activityTask, a.handleActivityTask)
+		a.ActivityTaskDispatcher.DispatchTask(activityTask, a.HandleActivityTask)
 	} else {
-		a.ActivityTaskDispatcher.DispatchTask(activityTask, a.handleWithRecovery(a.handleActivityTask))
+		a.ActivityTaskDispatcher.DispatchTask(activityTask, a.handleWithRecovery(a.HandleActivityTask))
 	}
 }
 
-func (a *ActivityWorker) handleActivityTask(activityTask *swf.PollForActivityTaskOutput) {
+// HandleActivityTask is the callback passed into the registered ActivityTaskDispatcher.
+// It is exposed so that users can handle polling themselves and call DispatchTask directly
+// with this as the callback.
+//
+// e.g.  activityWorker.ActivityTaskDispatcher.DispatchTask(activityTask, a.HandleActivityTask)
+//
+// Note: You will need to handle recovering from panics if you call this directly.
+func (a *ActivityWorker) HandleActivityTask(activityTask *swf.PollForActivityTaskOutput) {
 	a.ActivityInterceptor.BeforeTask(activityTask)
 	handler := a.handlers[*activityTask.ActivityType.Name]
 

--- a/activity/worker_test.go
+++ b/activity/worker_test.go
@@ -382,7 +382,7 @@ func TestStringHandler(t *testing.T) {
 
 	worker.AddHandler(NewActivityHandler("activity", handler))
 	worker.AddHandler(NewActivityHandler("nilactivity", nilHandler))
-	worker.handleActivityTask(&swf.PollForActivityTaskOutput{
+	worker.HandleActivityTask(&swf.PollForActivityTaskOutput{
 		WorkflowExecution: &swf.WorkflowExecution{},
 		ActivityType:      &swf.ActivityType{Name: S("activity")},
 		Input:             S("theInput"),
@@ -395,7 +395,7 @@ func TestStringHandler(t *testing.T) {
 	ops.Completed = nil
 	ops.CompletedSet = false
 
-	worker.handleActivityTask(&swf.PollForActivityTaskOutput{
+	worker.HandleActivityTask(&swf.PollForActivityTaskOutput{
 		WorkflowExecution: &swf.WorkflowExecution{},
 		ActivityType:      &swf.ActivityType{Name: S("nilactivity")},
 		Input:             S("theInput"),


### PR DESCRIPTION
The purpose of this would be to allow users to handle polling themselves, but still be able to use the handling that is built into the ActivityWorker.  

I also considered exposing `handleWithRecovery` so that they could still gracefully recover from panics without implementing themselves.  Thoughts?

My purpose for this... We are scheduling long running tasks to run on ECS.  These tasks can take weeks, so we separated the polling out into stateless services that can be killed without ramifications.  These stateless services call the ecs.RunTask api when they get a task in.  Now I want the containers running on ECS to use ActivityWorker, but without the polling.