### PR TITLE
Call Cancel after Tick completes

### DIFF
--- a/activity/coordinated_worker_test.go
+++ b/activity/coordinated_worker_test.go
@@ -52,6 +52,10 @@ func TestCoordinatedActivityHandler_Complete(t *testing.T) {
 	if !mockSwf.CompletedSet {
 		t.Fatal("Not Completed")
 	}
+
+	if !hc.canceled {
+		t.Fatal("was not canceled")
+	}
 }
 
 func TestCoordinatedActivityHandler_Cancel(t *testing.T) {
@@ -173,6 +177,10 @@ func TestTypedCoordinatedActivityHandler_Complete(t *testing.T) {
 
 	if !mockSwf.CompletedSet {
 		t.Fatal("Not Completed")
+	}
+
+	if !hc.canceled {
+		t.Fatal("was not canceled")
 	}
 }
 

--- a/activity/worker.go
+++ b/activity/worker.go
@@ -145,7 +145,6 @@ func (a *ActivityWorker) HandleActivityTask(activityTask *swf.PollForActivityTas
 				return
 			}
 		}
-
 	} else {
 		deserialized = nil
 	}

--- a/activity/worker_test.go
+++ b/activity/worker_test.go
@@ -408,10 +408,6 @@ func TestStringHandler(t *testing.T) {
 }
 
 func TestBackoff(t *testing.T) {
-	if os.Getenv("TEST_BACKOFF") != "1" {
-		t.Log("TEST_BACKOFF != 1  skipping test")
-	}
-
 	serializer := fsm.JSONStateSerializer{}
 
 	correlator := new(fsm.EventCorrelator)


### PR DESCRIPTION
Let's try this again!

The ultimate change is to call Cancel after Tick completes.

Along the way I discovered the coord worker tests weren't doing much because `cont` on `TestCoordinatedTaskHandler` was mostly `false`. Reworked them and added a new StartError case that verifies what happens when Start errors.

Would be nice to further reduce duplication across non-typed and typed tests but will leave that for another time.