### PR TITLE
Truncate long failure reasons in activity worker

### DIFF
--- a/activity/swfconstants.go
+++ b/activity/swfconstants.go
@@ -1,0 +1,6 @@
+package activity
+
+// Various constants defined by SWF
+const (
+	FailureReasonMaxChars = 256
+)


### PR DESCRIPTION
Closes #161 

Logging format is very consistent... wasn't sure how to make the truncate log message fit within the pattern.