### PR TITLE
Fix imports command, only fmt our code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,13 +29,12 @@ lint:
 	test -z "$$(golint ./... | tee /dev/stderr)"
 	go vet ./...
 
-
 imports:
 	go get golang.org/x/tools/cmd/goimports
-	goimports -d $(GO_PACKAGES) -w .
+	goimports -w -d $(GO_PACKAGES)
 
 fmt:
-	go fmt ./...
+	go fmt $(GO_PACKAGES)
 
 ready: fmt imports tidy
 


### PR DESCRIPTION
#169 introduced a few things which caused problems running `make` locally - a imports command had arguments out of order, and we were trying to format vendored code.

This fixes that.