### PR TITLE
Increase cancel buffer to two messages as heartbeat and signal could …

### DIFF
--- a/activity/coordinated_worker.go
+++ b/activity/coordinated_worker.go
@@ -86,7 +86,7 @@ func (c *coordinatedActivityAdapter) coordinate(activityTask *swf.PollForActivit
 		return nil, err
 	}
 
-	cancel := make(chan error, 1)
+	cancel := make(chan error, 2)
 	stopHeartbeating := make(chan struct{})
 
 	go c.heartbeat(activityTask, stopHeartbeating, cancel)


### PR DESCRIPTION
…both error

Potentially a race condition could occur where both heartbeat and signal error and try to send a message on the same cancel channel.  So I think the buffer needs to be 2.