### PR TITLE
[RFC] context.Context and Tracing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,6 @@ language: go
 go: 1.6.1
 before_install:
   - export PATH=$HOME/gopath/bin:$PATH
+  - go get ./...
 script: make travis
 sudo: false

--- a/activity/coordinated_worker.go
+++ b/activity/coordinated_worker.go
@@ -78,9 +78,9 @@ func (c *coordinatedActivityAdapter) heartbeat(activityTask *swf.PollForActivity
 }
 
 func (c *coordinatedActivityAdapter) coordinate(ctx context.Context, activityTask *swf.PollForActivityTaskOutput, input interface{}) (interface{}, error) {
-	defer c.finish(activityTask, input)
+	defer c.finish(ctx, activityTask, input)
 
-	update, err := c.handler.Start(activityTask, input)
+	update, err := c.handler.Start(ctx, activityTask, input)
 	if err != nil {
 		return nil, err
 	}
@@ -99,10 +99,10 @@ func (c *coordinatedActivityAdapter) coordinate(ctx context.Context, activityTas
 	for {
 		select {
 		case cause := <-cancel:
-			c.cancel(activityTask, input)
+			c.cancel(ctx, activityTask, input)
 			return nil, cause
 		case <-ticks.C:
-			cont, res, err := c.handler.Tick(activityTask, input)
+			cont, res, err := c.handler.Tick(ctx, activityTask, input)
 			if !cont {
 				return res, err
 			}
@@ -119,14 +119,14 @@ func (c *coordinatedActivityAdapter) coordinate(ctx context.Context, activityTas
 	}
 }
 
-func (c *coordinatedActivityAdapter) cancel(activityTask *swf.PollForActivityTaskOutput, input interface{}) {
-	if err := c.handler.Cancel(activityTask, input); err != nil {
+func (c *coordinatedActivityAdapter) cancel(ctx context.Context, activityTask *swf.PollForActivityTaskOutput, input interface{}) {
+	if err := c.handler.Cancel(ctx, activityTask, input); err != nil {
 		Log.Printf("workflow-id=%s activity-id=%s activity-id=%s at=activity-cancel-err error=%q", LS(activityTask.WorkflowExecution.WorkflowId), LS(activityTask.ActivityType.Name), LS(activityTask.ActivityId), err)
 	}
 }
 
-func (c *coordinatedActivityAdapter) finish(activityTask *swf.PollForActivityTaskOutput, input interface{}) {
-	if err := c.handler.Finish(activityTask, input); err != nil {
+func (c *coordinatedActivityAdapter) finish(ctx context.Context, activityTask *swf.PollForActivityTaskOutput, input interface{}) {
+	if err := c.handler.Finish(ctx, activityTask, input); err != nil {
 		Log.Printf("workflow-id=%s activity-id=%s activity-id=%s at=activity-finish-err error=%q", LS(activityTask.WorkflowExecution.WorkflowId), LS(activityTask.ActivityType.Name), LS(activityTask.ActivityId), err)
 	}
 }

--- a/activity/coordinated_worker.go
+++ b/activity/coordinated_worker.go
@@ -3,6 +3,8 @@ package activity
 import (
 	"time"
 
+	"golang.org/x/net/context"
+
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -75,7 +77,7 @@ func (c *coordinatedActivityAdapter) heartbeat(activityTask *swf.PollForActivity
 	}
 }
 
-func (c *coordinatedActivityAdapter) coordinate(activityTask *swf.PollForActivityTaskOutput, input interface{}) (interface{}, error) {
+func (c *coordinatedActivityAdapter) coordinate(ctx context.Context, activityTask *swf.PollForActivityTaskOutput, input interface{}) (interface{}, error) {
 	defer c.finish(activityTask, input)
 
 	update, err := c.handler.Start(activityTask, input)

--- a/activity/coordinated_worker_test.go
+++ b/activity/coordinated_worker_test.go
@@ -411,12 +411,12 @@ type TestCoordinatedTaskHandler struct {
 	ticks    int
 }
 
-func (c *TestCoordinatedTaskHandler) Start(a *swf.PollForActivityTaskOutput, d interface{}) (interface{}, error) {
+func (c *TestCoordinatedTaskHandler) Start(ctx context.Context, a *swf.PollForActivityTaskOutput, d interface{}) (interface{}, error) {
 	c.t.Log("START")
 	return nil, c.startErr
 }
 
-func (c *TestCoordinatedTaskHandler) Tick(a *swf.PollForActivityTaskOutput, d interface{}) (bool, interface{}, error) {
+func (c *TestCoordinatedTaskHandler) Tick(ctx context.Context, a *swf.PollForActivityTaskOutput, d interface{}) (bool, interface{}, error) {
 	c.ticks++
 	c.t.Log("TICK")
 	time.Sleep(100 * time.Millisecond)
@@ -426,13 +426,13 @@ func (c *TestCoordinatedTaskHandler) Tick(a *swf.PollForActivityTaskOutput, d in
 	return true, nil, nil
 }
 
-func (c *TestCoordinatedTaskHandler) Cancel(a *swf.PollForActivityTaskOutput, d interface{}) error {
+func (c *TestCoordinatedTaskHandler) Cancel(ctx context.Context, a *swf.PollForActivityTaskOutput, d interface{}) error {
 	c.t.Log("CANCEL")
 	c.canceled = true
 	return nil
 }
 
-func (c *TestCoordinatedTaskHandler) Finish(a *swf.PollForActivityTaskOutput, d interface{}) error {
+func (c *TestCoordinatedTaskHandler) Finish(ctx context.Context, a *swf.PollForActivityTaskOutput, d interface{}) error {
 	c.t.Log("FINISH")
 	c.finished = true
 	return nil
@@ -446,12 +446,12 @@ type TypedCoordinatedTaskHandler struct {
 	finished bool
 }
 
-func (c *TypedCoordinatedTaskHandler) Begin(a *swf.PollForActivityTaskOutput, d *TestInput) (*TestOutput, error) {
+func (c *TypedCoordinatedTaskHandler) Begin(ctx context.Context, a *swf.PollForActivityTaskOutput, d *TestInput) (*TestOutput, error) {
 	c.t.Log("START")
 	return nil, c.startErr
 }
 
-func (c *TypedCoordinatedTaskHandler) Work(a *swf.PollForActivityTaskOutput, d *TestInput) (bool, *TestOutput, error) {
+func (c *TypedCoordinatedTaskHandler) Work(ctx context.Context, a *swf.PollForActivityTaskOutput, d *TestInput) (bool, *TestOutput, error) {
 	c.t.Log("TICK")
 	time.Sleep(100 * time.Millisecond)
 	if c.stop {
@@ -460,13 +460,13 @@ func (c *TypedCoordinatedTaskHandler) Work(a *swf.PollForActivityTaskOutput, d *
 	return true, nil, nil
 }
 
-func (c *TypedCoordinatedTaskHandler) Stop(a *swf.PollForActivityTaskOutput, d *TestInput) error {
+func (c *TypedCoordinatedTaskHandler) Stop(ctx context.Context, a *swf.PollForActivityTaskOutput, d *TestInput) error {
 	c.t.Log("CANCEL")
 	c.canceled = true
 	return nil
 }
 
-func (c *TypedCoordinatedTaskHandler) Finish(a *swf.PollForActivityTaskOutput, d *TestInput) error {
+func (c *TypedCoordinatedTaskHandler) Finish(ctx context.Context, a *swf.PollForActivityTaskOutput, d *TestInput) error {
 	c.t.Log("FINISH")
 	c.finished = true
 	return nil

--- a/activity/coordinated_worker_test.go
+++ b/activity/coordinated_worker_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/aws/aws-sdk-go/service/swf"
 	. "github.com/sclasen/swfsm/sugar"
 )
@@ -32,7 +34,7 @@ func TestCoordinatedActivityHandler_Complete(t *testing.T) {
 	worker.Init()
 	input, _ := worker.Serializer.Serialize(&TestInput{Name: "Foo"})
 
-	go worker.HandleActivityTask(&swf.PollForActivityTaskOutput{
+	go worker.HandleActivityTask(context.Background(), &swf.PollForActivityTaskOutput{
 		TaskToken:         S("token"),
 		WorkflowExecution: &swf.WorkflowExecution{},
 		ActivityType: &swf.ActivityType{
@@ -80,7 +82,7 @@ func TestCoordinatedActivityHandler_Cancel(t *testing.T) {
 	worker.Init()
 	input, _ := worker.Serializer.Serialize(&TestInput{Name: "Foo"})
 
-	go worker.HandleActivityTask(&swf.PollForActivityTaskOutput{
+	go worker.HandleActivityTask(context.Background(), &swf.PollForActivityTaskOutput{
 		TaskToken:         S("token"),
 		WorkflowExecution: &swf.WorkflowExecution{},
 		ActivityType: &swf.ActivityType{
@@ -129,7 +131,7 @@ func TestCoordinatedActivityHandler_StartError(t *testing.T) {
 	worker.Init()
 	input, _ := worker.Serializer.Serialize(&TestInput{Name: "Foo"})
 
-	go worker.HandleActivityTask(&swf.PollForActivityTaskOutput{
+	go worker.HandleActivityTask(context.Background(), &swf.PollForActivityTaskOutput{
 		TaskToken:         S("token"),
 		WorkflowExecution: &swf.WorkflowExecution{},
 		ActivityType: &swf.ActivityType{
@@ -175,7 +177,7 @@ func TestCoordinatedActivityHandler_SendStartSignalError(t *testing.T) {
 
 	mockSwf.SignalFail = true
 
-	go worker.HandleActivityTask(&swf.PollForActivityTaskOutput{
+	go worker.HandleActivityTask(context.Background(), &swf.PollForActivityTaskOutput{
 		TaskToken:         S("token"),
 		WorkflowExecution: &swf.WorkflowExecution{},
 		ActivityType: &swf.ActivityType{
@@ -212,7 +214,7 @@ func TestTypedCoordinatedActivityHandler_Complete(t *testing.T) {
 	worker.Init()
 	input, _ := worker.Serializer.Serialize(&TestInput{Name: "Foo"})
 
-	go worker.HandleActivityTask(&swf.PollForActivityTaskOutput{
+	go worker.HandleActivityTask(context.Background(), &swf.PollForActivityTaskOutput{
 		TaskToken:         S("token"),
 		WorkflowExecution: &swf.WorkflowExecution{},
 		ActivityType: &swf.ActivityType{
@@ -253,7 +255,7 @@ func TestTypedCoordinatedActivityHandler_Cancel(t *testing.T) {
 	worker.Init()
 	input, _ := worker.Serializer.Serialize(&TestInput{Name: "Foo"})
 
-	go worker.HandleActivityTask(&swf.PollForActivityTaskOutput{
+	go worker.HandleActivityTask(context.Background(), &swf.PollForActivityTaskOutput{
 		TaskToken:         S("token"),
 		WorkflowExecution: &swf.WorkflowExecution{},
 		ActivityType: &swf.ActivityType{
@@ -295,7 +297,7 @@ func TestTypedCoordinatedActivityHandler_StartError(t *testing.T) {
 	worker.Init()
 	input, _ := worker.Serializer.Serialize(&TestInput{Name: "Foo"})
 
-	go worker.HandleActivityTask(&swf.PollForActivityTaskOutput{
+	go worker.HandleActivityTask(context.Background(), &swf.PollForActivityTaskOutput{
 		TaskToken:         S("token"),
 		WorkflowExecution: &swf.WorkflowExecution{},
 		ActivityType: &swf.ActivityType{
@@ -334,7 +336,7 @@ func TestTypedCoordinatedActivityHandler_SendStartSignalError(t *testing.T) {
 
 	mockSwf.SignalFail = true
 
-	go worker.HandleActivityTask(&swf.PollForActivityTaskOutput{
+	go worker.HandleActivityTask(context.Background(), &swf.PollForActivityTaskOutput{
 		TaskToken:         S("token"),
 		WorkflowExecution: &swf.WorkflowExecution{},
 		ActivityType: &swf.ActivityType{
@@ -377,7 +379,7 @@ func TestTickRateLimit(t *testing.T) {
 	worker.AddCoordinatedHandler(1*time.Second, 100*time.Millisecond, handler)
 	worker.Init()
 	input, _ := worker.Serializer.Serialize(&TestInput{Name: "Foo"})
-	go worker.HandleActivityTask(&swf.PollForActivityTaskOutput{
+	go worker.HandleActivityTask(context.Background(), &swf.PollForActivityTaskOutput{
 		TaskToken:         S("token"),
 		WorkflowExecution: &swf.WorkflowExecution{},
 		ActivityType: &swf.ActivityType{

--- a/activity/dispatchers_test.go
+++ b/activity/dispatchers_test.go
@@ -4,6 +4,8 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/aws/aws-sdk-go/service/swf"
 
 	"time"
@@ -45,7 +47,7 @@ func testDispatcher(dispatcher ActivityTaskDispatcher, t *testing.T) {
 	tasksHandled := int32(0)
 	totalTasks := int32(1000)
 	done := make(chan struct{}, 1)
-	handler := func(d *swf.PollForActivityTaskOutput) {
+	handler := func(ctx context.Context, d *swf.PollForActivityTaskOutput) {
 		handled := atomic.AddInt32(&tasksHandled, 1)
 		if handled == totalTasks {
 			done <- struct{}{}
@@ -53,7 +55,7 @@ func testDispatcher(dispatcher ActivityTaskDispatcher, t *testing.T) {
 	}
 
 	for i := int32(0); i < totalTasks; i++ {
-		dispatcher.DispatchTask(task, handler)
+		dispatcher.DispatchTask(context.Background(), task, handler)
 	}
 
 	select {

--- a/activity/handler_test.go
+++ b/activity/handler_test.go
@@ -3,12 +3,14 @@ package activity
 import (
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/aws/aws-sdk-go/service/swf"
 )
 
 func TestHandler(t *testing.T) {
 	handler := NewActivityHandler("activity", Handler)
-	ret, err := handler.HandlerFunc(&swf.PollForActivityTaskOutput{}, &TestInput{Name: "testIn"})
+	ret, err := handler.HandlerFunc(context.Background(), &swf.PollForActivityTaskOutput{}, &TestInput{Name: "testIn"})
 	if ret.(*TestOutput).Name != "testInOut" {
 		t.Fatal("Not testInOut")
 	}
@@ -17,16 +19,16 @@ func TestHandler(t *testing.T) {
 		t.Fatal("err not nil")
 	}
 
-	handler.HandlerFunc(&swf.PollForActivityTaskOutput{}, handler.ZeroInput())
+	handler.HandlerFunc(context.Background(), &swf.PollForActivityTaskOutput{}, handler.ZeroInput())
 
 	stringHandler := NewActivityHandler("activity", StringHandler)
-	ret, _ = stringHandler.HandlerFunc(&swf.PollForActivityTaskOutput{}, "foo")
+	ret, _ = stringHandler.HandlerFunc(context.Background(), &swf.PollForActivityTaskOutput{}, "foo")
 	if ret.(string) != "fooOut" {
 		t.Fatal("string not fooOut")
 	}
 
 	nilHandler := NewActivityHandler("activity", NilHandler)
-	ret, err = nilHandler.HandlerFunc(&swf.PollForActivityTaskOutput{}, &TestInput{Name: "testIn"})
+	ret, err = nilHandler.HandlerFunc(context.Background(), &swf.PollForActivityTaskOutput{}, &TestInput{Name: "testIn"})
 	if err != nil {
 		t.Fatal(ret, err)
 	}
@@ -37,15 +39,15 @@ func TestHandler(t *testing.T) {
 
 }
 
-func Handler(task *swf.PollForActivityTaskOutput, input *TestInput) (*TestOutput, error) {
+func Handler(ctx context.Context, task *swf.PollForActivityTaskOutput, input *TestInput) (*TestOutput, error) {
 	return &TestOutput{Name: input.Name + "Out"}, nil
 }
 
-func NilHandler(task *swf.PollForActivityTaskOutput, input *TestInput) (*TestOutput, error) {
+func NilHandler(ctx context.Context, task *swf.PollForActivityTaskOutput, input *TestInput) (*TestOutput, error) {
 	return nil, nil
 }
 
-func StringHandler(task *swf.PollForActivityTaskOutput, input string) (string, error) {
+func StringHandler(ctx context.Context, task *swf.PollForActivityTaskOutput, input string) (string, error) {
 	return input + "Out", nil
 }
 

--- a/activity/interceptors_test.go
+++ b/activity/interceptors_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/aws/aws-sdk-go/service/swf"
 	. "github.com/sclasen/swfsm/sugar"
 )
@@ -43,14 +45,14 @@ func TestInterceptors(t *testing.T) {
 
 	handler := &ActivityHandler{
 		Activity: "test",
-		HandlerFunc: func(activityTask *swf.PollForActivityTaskOutput, input interface{}) (interface{}, error) {
+		HandlerFunc: func(ctx context.Context, activityTask *swf.PollForActivityTaskOutput, input interface{}) (interface{}, error) {
 			return nil, nil
 		},
 	}
 
 	worker.AddHandler(handler)
 
-	worker.HandleActivityTask(task)
+	worker.HandleActivityTask(context.Background(), task)
 
 	if !calledBefore {
 		t.Fatal("no before")
@@ -66,7 +68,7 @@ func TestInterceptors(t *testing.T) {
 	calledBefore = false
 	calledComplete = false
 
-	worker.HandleActivityTask(task)
+	worker.HandleActivityTask(context.Background(), task)
 
 	if !calledBefore {
 		t.Fatal("no before")
@@ -112,13 +114,13 @@ func TestFailedInterceptor(t *testing.T) {
 	}
 	handler := &ActivityHandler{
 		Activity: "test",
-		HandlerFunc: func(activityTask *swf.PollForActivityTaskOutput, input interface{}) (interface{}, error) {
+		HandlerFunc: func(ctx context.Context, activityTask *swf.PollForActivityTaskOutput, input interface{}) (interface{}, error) {
 			return nil, errors.New("fail")
 		},
 	}
 
 	worker.AddHandler(handler)
-	worker.HandleActivityTask(task)
+	worker.HandleActivityTask(context.Background(), task)
 	if !calledBefore {
 		t.Fatal("no before")
 	}
@@ -165,13 +167,13 @@ func TestCanceledInterceptor(t *testing.T) {
 	}
 	handler := &ActivityHandler{
 		Activity: "test",
-		HandlerFunc: func(activityTask *swf.PollForActivityTaskOutput, input interface{}) (interface{}, error) {
+		HandlerFunc: func(ctx context.Context, activityTask *swf.PollForActivityTaskOutput, input interface{}) (interface{}, error) {
 			return nil, ActivityTaskCanceledError{details: "details"}
 		},
 	}
 
 	worker.AddHandler(handler)
-	worker.HandleActivityTask(task)
+	worker.HandleActivityTask(context.Background(), task)
 	if !calledBefore {
 		t.Fatal("no before")
 	}

--- a/fsm/correlator_test.go
+++ b/fsm/correlator_test.go
@@ -6,6 +6,8 @@ import (
 	"reflect"
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/aws/aws-sdk-go/service/swf"
 	. "github.com/sclasen/swfsm/log"
 	. "github.com/sclasen/swfsm/sugar"
@@ -118,7 +120,7 @@ func TestTrackPendingActivities(t *testing.T) {
 	}
 	first := testDecisionTask(0, events)
 
-	_, decisions, _, _ := fsm.Tick(first)
+	_, decisions, _, _ := fsm.Tick(context.Background(), first)
 	recordMarker := FindDecision(decisions, stateMarkerPredicate)
 	if recordMarker == nil {
 		t.Fatal("No Record State Marker")
@@ -159,7 +161,7 @@ func TestTrackPendingActivities(t *testing.T) {
 	}
 	second := testDecisionTask(3, secondEvents)
 
-	_, secondDecisions, _, _ := fsm.Tick(second)
+	_, secondDecisions, _, _ := fsm.Tick(context.Background(), second)
 	recordMarker = FindDecision(secondDecisions, stateMarkerPredicate)
 	if recordMarker == nil {
 		t.Fatal("No Record State Marker")
@@ -199,7 +201,7 @@ func TestTrackPendingActivities(t *testing.T) {
 		t.Fatal("current state is not 'working'", thirdEvents)
 	}
 	third := testDecisionTask(7, thirdEvents)
-	_, thirdDecisions, _, _ := fsm.Tick(third)
+	_, thirdDecisions, _, _ := fsm.Tick(context.Background(), third)
 	recordMarker = FindDecision(thirdDecisions, stateMarkerPredicate)
 	if recordMarker == nil {
 		t.Fatal("No Record State Marker")
@@ -240,7 +242,7 @@ func TestTrackPendingActivities(t *testing.T) {
 		t.Fatal("current state is not 'done'", fourthEvents)
 	}
 	fourth := testDecisionTask(11, fourthEvents)
-	_, fourthDecisions, _, _ := fsm.Tick(fourth)
+	_, fourthDecisions, _, _ := fsm.Tick(context.Background(), fourth)
 	recordMarker = FindDecision(fourthDecisions, stateMarkerPredicate)
 	if recordMarker == nil {
 		t.Fatal("No Record State Marker")

--- a/fsm/deciders_test.go
+++ b/fsm/deciders_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/swf"
 	"github.com/stretchr/testify/assert"
@@ -477,7 +479,7 @@ func TestCompleteWorkflow(t *testing.T) {}
 func TestFailWorkflow(t *testing.T) {
 	// arrange
 	data := &TestingType{"Some data"}
-	fsmContext := NewFSMContext(nil,
+	fsmContext := NewFSMContext(context.Background(), nil,
 		swf.WorkflowType{Name: s.S("foo"), Version: s.S("1")},
 		swf.WorkflowExecution{WorkflowId: s.S("id"), RunId: s.S("runid")},
 		nil, "state", nil, 1)
@@ -516,7 +518,7 @@ func testContextWithSignal(scheduledEventId int, event *swf.SignalExternalWorkfl
 			SignalExternalWorkflowExecutionInitiatedEventAttributes: event,
 		})
 
-		return NewFSMContext(nil,
+		return NewFSMContext(context.Background(), nil,
 			swf.WorkflowType{Name: s.S("foo"), Version: s.S("1")},
 			swf.WorkflowExecution{WorkflowId: s.S("id"), RunId: s.S("runid")},
 			correlator, "state", nil, 1)
@@ -524,7 +526,7 @@ func testContextWithSignal(scheduledEventId int, event *swf.SignalExternalWorkfl
 }
 
 func deciderTestContext() *FSMContext {
-	return NewFSMContext(nil,
+	return NewFSMContext(context.Background(), nil,
 		swf.WorkflowType{Name: s.S("foo"), Version: s.S("1")},
 		swf.WorkflowExecution{WorkflowId: s.S("id"), RunId: s.S("runid")},
 		nil, "state", nil, 1)

--- a/fsm/dispatchers_test.go
+++ b/fsm/dispatchers_test.go
@@ -4,6 +4,8 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/swf"
 
@@ -36,7 +38,7 @@ func testDispatcher(dispatcher DecisionTaskDispatcher, t *testing.T) {
 	tasksHandled := int32(0)
 	totalTasks := int32(1000)
 	done := make(chan struct{}, 1)
-	handler := func(d *swf.PollForDecisionTaskOutput) {
+	handler := func(ctx context.Context, d *swf.PollForDecisionTaskOutput) {
 		handled := atomic.AddInt32(&tasksHandled, 1)
 		if handled == totalTasks {
 			done <- struct{}{}
@@ -44,7 +46,7 @@ func testDispatcher(dispatcher DecisionTaskDispatcher, t *testing.T) {
 	}
 
 	for i := int32(0); i < totalTasks; i++ {
-		dispatcher.DispatchTask(task, handler)
+		dispatcher.DispatchTask(context.Background(), task, handler)
 	}
 
 	select {

--- a/fsm/fsm.go
+++ b/fsm/fsm.go
@@ -403,6 +403,8 @@ func (f *FSM) Tick(ctx context.Context, decisionTask *swf.PollForDecisionTaskOut
 			opentracing.ChildOf(sp.Context()))
 	}
 	defer sp.Finish()
+	sp.SetTag("WorkflowType", *decisionTask.WorkflowType)
+	sp.SetTag("WorkflowID", *decisionTask.WorkflowExecution)
 
 	//BeforeDecision interceptor invocation
 	if f.DecisionInterceptor != nil {

--- a/fsm/fsm.go
+++ b/fsm/fsm.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"reflect"
 
+	"golang.org/x/net/context"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/swf"
 	"github.com/juju/errors"
@@ -334,12 +336,12 @@ func (f *FSM) taskReady(task *swf.PollForDecisionTaskOutput) bool {
 	return false
 }
 
-func (f *FSM) dispatchTask(decisionTask *swf.PollForDecisionTaskOutput) {
-	f.DecisionTaskDispatcher.DispatchTask(decisionTask, f.handleDecisionTask)
+func (f *FSM) dispatchTask(ctx context.Context, decisionTask *swf.PollForDecisionTaskOutput) {
+	f.DecisionTaskDispatcher.DispatchTask(ctx, decisionTask, f.handleDecisionTask)
 }
 
-func (f *FSM) handleDecisionTask(decisionTask *swf.PollForDecisionTaskOutput) {
-	context, decisions, state, err := f.Tick(decisionTask)
+func (f *FSM) handleDecisionTask(ctx context.Context, decisionTask *swf.PollForDecisionTaskOutput) {
+	context, decisions, state, err := f.Tick(ctx, decisionTask)
 	if err != nil {
 		f.TaskErrorHandler(decisionTask, err)
 		return
@@ -390,14 +392,14 @@ func (f *FSM) Deserialize(serialized string, data interface{}) {
 // Tick is called when the DecisionTaskPoller receives a PollForDecisionTaskResponse in its polling loop.
 // On errors, a nil *SerializedState is returned, and an error Outcome is included in the Decision list.
 // It is exported to facilitate testing.
-func (f *FSM) Tick(decisionTask *swf.PollForDecisionTaskOutput) (*FSMContext, []*swf.Decision, *SerializedState, error) {
+func (f *FSM) Tick(ctx context.Context, decisionTask *swf.PollForDecisionTaskOutput) (*FSMContext, []*swf.Decision, *SerializedState, error) {
 	//BeforeDecision interceptor invocation
 	if f.DecisionInterceptor != nil {
 		f.DecisionInterceptor.BeforeTask(decisionTask)
 	}
 	lastEvents := f.findLastEvents(*decisionTask.PreviousStartedEventId, decisionTask.Events)
 	outcome := new(Outcome)
-	context := NewFSMContext(f,
+	context := NewFSMContext(ctx, f,
 		*decisionTask.WorkflowType,
 		*decisionTask.WorkflowExecution,
 		nil,
@@ -583,7 +585,7 @@ func (f *FSM) ErrorStateTick(decisionTask *swf.PollForDecisionTaskOutput, error 
 	filteredDecisionTask.StartedEventId = &error.LatestUnprocessedEventId
 	filteredDecisionTask.PreviousStartedEventId = &error.EarliestUnprocessedEventId
 
-	_, decisions, serializedState, err := f.Tick(filteredDecisionTask)
+	_, decisions, serializedState, err := f.Tick(context.RequestContext(), filteredDecisionTask)
 	if err != nil {
 		data := f.zeroStateData()
 		f.Deserialize(serializedState.StateData, data)

--- a/fsm/fsm_context.go
+++ b/fsm/fsm_context.go
@@ -3,6 +3,7 @@ package fsm
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/swf"
+	"github.com/opentracing/opentracing-go"
 	"golang.org/x/net/context"
 
 	. "github.com/sclasen/swfsm/sugar"
@@ -43,6 +44,16 @@ func NewFSMContext(
 // request poll
 func (f *FSMContext) RequestContext() context.Context {
 	return f.requestContext
+}
+
+// RequestSpan returns the opentracing.Span associated with the SWF task
+// request poll, or a new root span if that is not set
+func (f *FSMContext) RequestSpan() opentracing.Span {
+	sp := opentracing.SpanFromContext(f.requestContext)
+	if sp == nil {
+		sp, f.requestContext = opentracing.StartSpanFromContext(f.requestContext, "fsm_context")
+	}
+	return sp
 }
 
 func (f *FSMContext) InitialState() string {

--- a/fsm/fsm_context.go
+++ b/fsm/fsm_context.go
@@ -3,13 +3,15 @@ package fsm
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/swf"
+	"golang.org/x/net/context"
 
 	. "github.com/sclasen/swfsm/sugar"
 )
 
 // FSMContext is populated by the FSM machinery and passed to Deciders.
 type FSMContext struct {
-	serialization Serialization
+	requestContext context.Context
+	serialization  Serialization
 	swf.WorkflowType
 	swf.WorkflowExecution
 	eventCorrelator *EventCorrelator
@@ -20,11 +22,13 @@ type FSMContext struct {
 
 // NewFSMContext constructs an FSMContext.
 func NewFSMContext(
+	ctx context.Context,
 	serialization Serialization,
 	wfType swf.WorkflowType, wfExec swf.WorkflowExecution,
 	eventCorrelator *EventCorrelator,
 	state string, stateData interface{}, stateVersion uint64) *FSMContext {
 	return &FSMContext{
+		requestContext:    ctx,
 		serialization:     serialization,
 		WorkflowType:      wfType,
 		WorkflowExecution: wfExec,
@@ -33,6 +37,12 @@ func NewFSMContext(
 		stateData:         stateData,
 		stateVersion:      stateVersion,
 	}
+}
+
+// RequestContext returns the context.Context associated with the SWF task
+// request poll
+func (f *FSMContext) RequestContext() context.Context {
+	return f.requestContext
 }
 
 func (f *FSMContext) InitialState() string {

--- a/fsm/fsm_test.go
+++ b/fsm/fsm_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"errors"
 	"reflect"
 
@@ -90,7 +92,7 @@ func TestFSM(t *testing.T) {
 
 	first := testDecisionTask(0, events)
 
-	_, decisions, _, err := fsm.Tick(first)
+	_, decisions, _, err := fsm.Tick(context.Background(), first)
 
 	if err != nil {
 		t.Fatal(err)
@@ -121,7 +123,7 @@ func TestFSM(t *testing.T) {
 
 	second := testDecisionTask(3, secondEvents)
 
-	_, secondDecisions, _, err := fsm.Tick(second)
+	_, secondDecisions, _, err := fsm.Tick(context.Background(), second)
 
 	if err != nil {
 		t.Fatal(err)
@@ -162,7 +164,7 @@ func TestFSMError(t *testing.T) {
 	tasks := testDecisionTask(0, events)
 
 	fsm.AllowPanics = false
-	_, decisions, _, err := fsm.Tick(tasks)
+	_, decisions, _, err := fsm.Tick(context.Background(), tasks)
 
 	if err != nil {
 		t.Fatal(err)
@@ -482,7 +484,7 @@ func TestContinuedWorkflows(t *testing.T) {
 	}})
 
 	Log.Printf("%+v", resp)
-	_, decisions, updatedState, _ := fsm.Tick(resp)
+	_, decisions, updatedState, _ := fsm.Tick(context.Background(), resp)
 
 	Log.Println(updatedState)
 
@@ -678,7 +680,7 @@ func TestHandleDecisionTaskWhenTickErrorsExpectsTaskErrorHandlerCalled(t *testin
 	f.AllowPanics = false
 
 	// act
-	f.handleDecisionTask(decisionTask)
+	f.handleDecisionTask(context.Background(), decisionTask)
 
 	// assert
 	assert.True(t, handlerCalled, "Expected handler called because Tick errored")
@@ -712,7 +714,7 @@ func TestHandleDecisionTaskWhenRespondingToSWFErrorsExpectsTaskErrorHandlerCalle
 
 	// act
 	f.Init()
-	f.handleDecisionTask(decisionTask)
+	f.handleDecisionTask(context.Background(), decisionTask)
 
 	// assert
 	assert.True(t, handlerCalled, "Expected handler called because RespondDecisionTaskCompleted errored")
@@ -748,7 +750,7 @@ func TestHandleDecisionTaskReplicationErrorsExpectsTaskErrorHandlerCalled(t *tes
 
 	// act
 	f.Init()
-	f.handleDecisionTask(decisionTask)
+	f.handleDecisionTask(context.Background(), decisionTask)
 
 	// assert
 	assert.True(t, handlerCalled, "Expected handler called because there was a replication error")
@@ -783,7 +785,7 @@ func TestHandleDecisionTaskWhenNoErrorsExpectsTaskErrorHandlerNotCalled(t *testi
 
 	// act
 	f.Init()
-	f.handleDecisionTask(decisionTask)
+	f.handleDecisionTask(context.Background(), decisionTask)
 
 	// assert
 	assert.False(t, handlerCalled, "Expected handler not called because nothing errored")
@@ -802,6 +804,7 @@ func testFSM() *FSM {
 
 func testContext(fsm *FSM) *FSMContext {
 	return NewFSMContext(
+		context.Background(),
 		fsm,
 		swf.WorkflowType{Name: S("test-workflow"), Version: S("1")},
 		swf.WorkflowExecution{WorkflowId: S("test-workflow-1"), RunId: S("123123")},

--- a/fsm/interceptors_test.go
+++ b/fsm/interceptors_test.go
@@ -3,6 +3,8 @@ package fsm
 import (
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/aws/aws-sdk-go/service/swf"
 	. "github.com/sclasen/swfsm/sugar"
 )
@@ -62,7 +64,7 @@ func TestInterceptors(t *testing.T) {
 		},
 	}
 
-	_, ds, _, _ := fsm.Tick(decisionTask)
+	_, ds, _, _ := fsm.Tick(context.Background(), decisionTask)
 
 	if calledBefore == false {
 		t.Fatalf("before not called")
@@ -606,7 +608,7 @@ func TestMixedDecisionInterceptions(t *testing.T) {
 }
 
 func interceptorTestContext() *FSMContext {
-	return NewFSMContext(&FSM{Serializer: &JSONStateSerializer{}},
+	return NewFSMContext(context.Background(), &FSM{Serializer: &JSONStateSerializer{}},
 		swf.WorkflowType{Name: S("foo"), Version: S("1")},
 		swf.WorkflowExecution{WorkflowId: S("id"), RunId: S("runid")},
 		&EventCorrelator{}, "state", "data", 1)

--- a/fsm/replicators_test.go
+++ b/fsm/replicators_test.go
@@ -5,6 +5,8 @@ import (
 	"strconv"
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/aws/aws-sdk-go/service/kinesis"
 	"github.com/aws/aws-sdk-go/service/swf"
 	. "github.com/sclasen/swfsm/sugar"
@@ -74,7 +76,7 @@ func TestKinesisReplication(t *testing.T) {
 	}
 	decisionTask := testDecisionTask(0, events)
 
-	fsm.handleDecisionTask(decisionTask)
+	fsm.handleDecisionTask(context.Background(), decisionTask)
 
 	if client.putRecords == nil || len(client.putRecords) != 1 {
 		t.Fatalf("expected only one state to be replicated, got: %v", client.putRecords)

--- a/poller/poller.go
+++ b/poller/poller.go
@@ -129,6 +129,7 @@ func (p *DecisionTaskPoller) PollUntilShutdownBy(mgr *ShutdownManager, pollerNam
 			ctx := context.WithValue(context.Background(), "RequestID", pollID)
 			// Start a span. Discard it unless we process to handling tasks
 			sp, ctx := opentracing.StartSpanFromContext(ctx, "decision_task_poll")
+			sp.SetTag("RequestID", pollID)
 			task, err := p.poll(ctx, pollID, taskReady)
 			if err != nil {
 				Log.Printf("component=DecisionTaskPoller fn=PollUntilShutdownBy at=poll-err poller=%s task-list=%q error=%q", pollerName, p.TaskList, err)

--- a/testing/stubs_test.go
+++ b/testing/stubs_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	te "testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/aws/aws-sdk-go/service/swf"
 	"github.com/sclasen/swfsm/fsm"
 	. "github.com/sclasen/swfsm/sugar"
@@ -193,7 +195,8 @@ func TestThrottleInterceptors(t *te.T) {
 }
 
 func interceptorTestContext() *fsm.FSMContext {
-	return fsm.NewFSMContext(&fsm.FSM{Serializer: &fsm.JSONStateSerializer{}},
+	return fsm.NewFSMContext(context.Background(),
+		&fsm.FSM{Serializer: &fsm.JSONStateSerializer{}},
 		swf.WorkflowType{Name: S("foo"), Version: S("1")},
 		swf.WorkflowExecution{WorkflowId: S("id"), RunId: S("runid")},
 		&fsm.EventCorrelator{}, "state", "data", 1)


### PR DESCRIPTION
Hi All, Opening this partial PR to request some commentary and discussion around the ideas here.

tl;dr - introducing `context.Context` for 'requests' from AWS, and starting annotations with [OpenTracing](http://opentracing.io/). The former _does not_ require the latter to happen.

The first component is the introduction of [`context.Context`](https://godoc.org/golang.org/x/net/context) to our "Requests". Whilst technically this library doesn't directly initiate requests, the tasks we get from SWF essentially represent this so we should treat them as such. The context isn't really used initially apart from carrying a RequestID, but it gets us the foundations for moving request scoped data and timeouts through these calls. This can be particular useful for activities that make futher remote/rpc calls in to other systems. Because we already have the commonly used `FSMContext`, in places where this is passed a method is provided on it to get the request context. Otherwise a `context.Context` is passed as the first param as is custom.

Secondly, we start to introduce [OpenTracing](http://opentracing.io/), with the context being the method to transport it around. Spans are started/finished where it makes sense (aws request, decision tasks). The span information is passed via the `context.Context`, and a helper is provided on `fsm.Context` as well. This can be used to add spans or events as it makes sense. This gives the library consumer the option to plug in a tracing mechanism, and provide more explicit and context oriented views in to the flow than logging does.

What do people think about the direction this is going in? If there aren't any objections, I'd like to pursue this further.
