### PR TITLE
Log Panic Site in Decider/Activity recovery handler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
-go: 1.6.1
+go: 1.7.1
 before_install:
   - export PATH=$HOME/gopath/bin:$PATH
   - go get ./...

--- a/activity/worker.go
+++ b/activity/worker.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/swf"
 	"github.com/juju/errors"
 	"github.com/sclasen/swfsm/fsm"
+	"github.com/sclasen/swfsm/internal/panicinfo"
 	. "github.com/sclasen/swfsm/log"
 	"github.com/sclasen/swfsm/poller"
 	. "github.com/sclasen/swfsm/sugar"
@@ -306,12 +307,13 @@ func (h *ActivityWorker) HandleWithRecovery(handler func(*swf.PollForActivityTas
 		defer func() {
 			var anErr error
 			if r := recover(); r != nil {
+				file, line, name := panicinfo.LocatePanic(r)
 				if err, ok := r.(error); ok && err != nil {
 					anErr = err
 				} else {
 					anErr = errors.New("panic in activity with nil error")
 				}
-				Log.Printf("component=activity at=activity-panic-recovery-error error=%q", r)
+				Log.Printf("component=activity at=activity-panic-recovery-error func=%q file=\"%s:%d\" error=%q", name, file, line, r)
 				h.fail(resp, anErr)
 			}
 		}()

--- a/fsm/fsm.go
+++ b/fsm/fsm.go
@@ -70,7 +70,10 @@ type FSM struct {
 	FSMErrorReporter FSMErrorReporter
 	//AllowPanics is mainly for testing, it should be set to false in production.
 	//when true, instead of recovering from panics in deciders, it allows them to propagate.
-	AllowPanics   bool
+	AllowPanics bool
+	// Logger is used for output on a FSM. If not set, will use log.Log
+	Logger StdLogger
+
 	states        map[string]*FSMState
 	errorHandlers map[string]DecisionErrorHandler
 	initialState  *FSMState
@@ -697,12 +700,20 @@ func (f *FSM) EventData(event *swf.HistoryEvent, eventData interface{}) {
 
 func (f *FSM) log(format string, data ...interface{}) {
 	actualFormat := fmt.Sprintf("component=FSM name=%s %s", f.Name, format)
-	Log.Printf(actualFormat, data...)
+	if f.Logger != nil {
+		f.Logger.Printf(actualFormat, data...)
+	} else {
+		Log.Printf(actualFormat, data...)
+	}
 }
 
 func (f *FSM) clog(ctx *FSMContext, format string, data ...interface{}) {
 	actualFormat := fmt.Sprintf("component=FSM name=%s type=%s id=%s %s", f.Name, s.LS(ctx.WorkflowType.Name), s.LS(ctx.WorkflowId), format)
-	Log.Printf(actualFormat, data...)
+	if f.Logger != nil {
+		f.Logger.Printf(actualFormat, data...)
+	} else {
+		Log.Printf(actualFormat, data...)
+	}
 }
 
 func (f *FSM) findSerializedState(events []*swf.HistoryEvent) (*SerializedState, error) {

--- a/fsm/fsm.go
+++ b/fsm/fsm.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/swf"
 	"github.com/juju/errors"
+	"github.com/sclasen/swfsm/internal/panicinfo"
 	. "github.com/sclasen/swfsm/log"
 	"github.com/sclasen/swfsm/poller"
 	s "github.com/sclasen/swfsm/sugar"
@@ -637,7 +638,8 @@ func (f *FSM) panicSafeDecide(state *FSMState, context *FSMContext, event *swf.H
 	defer func() {
 		if !f.AllowPanics {
 			if r := recover(); r != nil {
-				f.log("at=decide-panic-recovery error=%q", r)
+				file, line, name := panicinfo.LocatePanic(r)
+				f.log("at=decide-panic-recovery func=%q file=\"%s:%d\" error=%q", name, file, line, r)
 				if err, ok := r.(error); ok && err != nil {
 					anErr = errors.Trace(err)
 				} else {

--- a/fsm/fsm_panic_test.go
+++ b/fsm/fsm_panic_test.go
@@ -1,0 +1,97 @@
+package fsm
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/swf"
+	"github.com/sclasen/swfsm/log"
+)
+
+type TypeData struct{}
+
+// Note - these vars must remain in the same place, or the expected panic lines
+// should be updated
+func untypedDecider(f *FSMContext, e *swf.HistoryEvent, data interface{}) Outcome {
+	panic("can you handle it?")
+}
+
+func typedDeciderFunc(f *FSMContext, h *swf.HistoryEvent, d *TypeData) Outcome {
+	panic("lol i tricked you")
+}
+
+var typedDecider = Typed(new(TypeData)).Decider(typedDeciderFunc)
+
+var typedDeciderAnon = Typed(new(TypeData)).Decider(func(f *FSMContext, h *swf.HistoryEvent, d *TypeData) Outcome {
+	panic("lol i tricked you")
+})
+
+var fileMatch = regexp.MustCompile(`file=\"([\w\/\.]+):(\d+)\"`)
+var fnMatch = regexp.MustCompile(`func=\"([\w\/\.]+)\"`)
+
+func TestPanicRecovery(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		decider Decider
+		data    interface{}
+		fn      string
+		file    string
+		line    string
+	}{
+		{
+			name:    "Non-typed",
+			decider: untypedDecider,
+			data:    nil,
+			fn:      "fsm.untypedDecider",
+			file:    "fsm_panic_test.go",
+			line:    "17", // this is the func above
+		},
+		{
+			name:    "Typed",
+			decider: typedDecider,
+			data:    &TypeData{},
+			fn:      "fsm.typedDeciderFunc",
+			file:    "fsm_panic_test.go",
+			line:    "21", // this is the func above
+		},
+		{
+			name:    "Typed Anonymous Function",
+			decider: typedDeciderAnon,
+			data:    &TypeData{},
+			fn:      "fsm.glob..func",
+			file:    "fsm_panic_test.go",
+			line:    "27", // this is the func above
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cl := &log.CapturingLogger{}
+			ts := &FSMState{
+				Name:    "panic",
+				Decider: tc.decider,
+			}
+			tf := &FSM{Logger: cl}
+			tf.AddInitialState(ts)
+			_, err := tf.panicSafeDecide(ts, new(FSMContext), &swf.HistoryEvent{}, tc.data)
+			if err == nil {
+				t.Errorf("%s: Panic expected, but not received", tc.name)
+			} else {
+				t.Log(err)
+			}
+			var fn, file, line string
+			for _, l := range cl.Lines {
+				if m := fileMatch.FindStringSubmatch(l); m != nil {
+					file = m[1]
+					line = m[2]
+				}
+				if m := fnMatch.FindStringSubmatch(l); m != nil {
+					fn = m[1]
+				}
+			}
+			if !strings.Contains(fn, tc.fn) || !strings.Contains(file, tc.file) || line != tc.line {
+				t.Errorf("Expected data not found in log line, found file: %s, line: %s, func: %s, expected file: %s, line: %s, func: %s",
+					file, line, fn, tc.file, tc.line, tc.fn)
+			}
+		})
+	}
+}

--- a/fsm/fsm_test.go
+++ b/fsm/fsm_test.go
@@ -289,27 +289,10 @@ func TestMarshalledDecider(t *testing.T) {
 	}
 }
 
-func TestPanicRecovery(t *testing.T) {
-	s := &FSMState{
-		Name: "panic",
-		Decider: func(f *FSMContext, e *swf.HistoryEvent, data interface{}) Outcome {
-			panic("can you handle it?")
-		},
-	}
-	f := &FSM{}
-	f.AddInitialState(s)
-	_, err := f.panicSafeDecide(s, new(FSMContext), &swf.HistoryEvent{}, nil)
-	if err == nil {
-		t.Fatal("fatallz")
-	} else {
-		Log.Println(err)
-	}
-}
-
 func ExampleFSM() {
 	// create with swf.NewClient
 	var client *swf.SWF
-	// data type that will be managed by the FSM
+	// data type that will be managed by the
 	type StateData struct {
 		Message string `json:"message,omitempty"`
 		Count   int    `json:"count,omitempty"`

--- a/internal/panicinfo/panic.go
+++ b/internal/panicinfo/panic.go
@@ -1,0 +1,32 @@
+package panicinfo
+
+import (
+	"runtime"
+	"strings"
+)
+
+// LocatePanic takes result of recover(), and will return the file name, line
+// and function name that triggered the panic
+func LocatePanic(r interface{}) (file string, line int, funcName string) {
+	defer func() {
+		// Be safe in here
+		recover()
+	}()
+	var pc [16]uintptr
+
+	// Need to start 4 deep
+	n := runtime.Callers(4, pc[:])
+	for _, pc := range pc[:n] {
+		fn := runtime.FuncForPC(pc)
+		if fn == nil {
+			continue
+		}
+		file, line = fn.FileLine(pc)
+		funcName = fn.Name()
+		if !strings.HasPrefix(funcName, "runtime.") {
+			break
+		}
+	}
+
+	return file, line, funcName
+}

--- a/internal/panicinfo/panic_test.go
+++ b/internal/panicinfo/panic_test.go
@@ -1,0 +1,26 @@
+package panicinfo
+
+import (
+	"strings"
+	"testing"
+)
+
+var file, name string
+var line int
+
+func TestPanicHandler(t *testing.T) {
+	panicFunc()
+	// Line needs to match our panic call below!
+	if !strings.HasSuffix(file, "panic_test.go") || !strings.HasSuffix(name, "panicFunc") || line != 25 {
+		t.Error("Panic handler did not collect expected information")
+	}
+}
+
+func panicFunc() {
+	defer func() {
+		// Be safe in here
+		r := recover()
+		file, line, name = LocatePanic(r)
+	}()
+	panic("lol I paniced")
+}

--- a/log/log.go
+++ b/log/log.go
@@ -1,6 +1,7 @@
 package log
 
 import (
+	"fmt"
 	golog "log"
 	"os"
 )
@@ -28,3 +29,36 @@ type StdLogger interface {
 //provide a mutable logger so it can be changed
 //this is what the default logger in go's log pakcage looks like
 var Log StdLogger = golog.New(os.Stderr, "", golog.LstdFlags)
+
+// CapturingLogger is designed to be used in testing - it will saves lines it receives
+type CapturingLogger struct {
+	Lines []string
+}
+
+func (c *CapturingLogger) Print(a ...interface{}) {
+	c.Lines = append(c.Lines, fmt.Sprint(a...))
+}
+func (c *CapturingLogger) Printf(s string, a ...interface{}) {
+	c.Lines = append(c.Lines, fmt.Sprintf(s, a...))
+}
+func (c *CapturingLogger) Println(a ...interface{}) {
+	c.Lines = append(c.Lines, fmt.Sprint(a...))
+}
+func (c *CapturingLogger) Fatal(a ...interface{}) {
+	c.Lines = append(c.Lines, fmt.Sprint(a...))
+}
+func (c *CapturingLogger) Fatalf(s string, a ...interface{}) {
+	c.Lines = append(c.Lines, fmt.Sprintf(s, a...))
+}
+func (c *CapturingLogger) Fatalln(a ...interface{}) {
+	c.Lines = append(c.Lines, fmt.Sprint(a...))
+}
+func (c *CapturingLogger) Panic(a ...interface{}) {
+	c.Lines = append(c.Lines, fmt.Sprint(a...))
+}
+func (c *CapturingLogger) Panicf(s string, a ...interface{}) {
+	c.Lines = append(c.Lines, fmt.Sprintf(s, a...))
+}
+func (c *CapturingLogger) Panicln(a ...interface{}) {
+	c.Lines = append(c.Lines, fmt.Sprint(a...))
+}


### PR DESCRIPTION
Closes #135 

When a panic occurs, this will walk back up the caller tree to find out where the panic occured, and log that information. e.g:

```
2016/10/03 14:37:41 component=FSM name= at=decide-panic-recovery func="github.com/sclasen/swfsm/fsm.TestPanicRecovery.func1" file="/home/lstoll/src/github.com/sclasen/swfsm/fsm/fsm_test.go:296" error="can you handle it?"
```

 