### PR TITLE
Find all walk empty break

### DIFF
--- a/fsm/client.go
+++ b/fsm/client.go
@@ -220,6 +220,7 @@ func (c *client) FindAllWalk(input *FindInput, fn func(info *swf.WorkflowExecuti
 
 		input.OpenNextPageToken = output.OpenNextPageToken
 		input.ClosedNextPageToken = output.ClosedNextPageToken
+		cont = cont && hasNextPage
 	}
 
 	return nil

--- a/fsm/client.go
+++ b/fsm/client.go
@@ -201,8 +201,8 @@ func (c *client) FindAll(input *FindInput) (output *FindOutput, err error) {
 func (c *client) FindAllWalk(input *FindInput, fn func(info *swf.WorkflowExecutionInfo, done bool) (cont bool)) error {
 	f := NewFinder(c.f.Domain, c.c)
 
-	cont := true
-	for cont {
+	var done bool
+	for !done {
 		output, err := f.FindAll(input)
 		if err != nil {
 			return err
@@ -211,20 +211,19 @@ func (c *client) FindAllWalk(input *FindInput, fn func(info *swf.WorkflowExecuti
 		hasNextPage := output.OpenNextPageToken != nil || output.ClosedNextPageToken != nil
 
 		for i, info := range output.ExecutionInfos {
-			if !cont {
-				return nil
+			done = !hasNextPage && i+1 == len(output.ExecutionInfos) // done because paging+iteration
+			done = !fn(info, done) || done                           // done because fn
+			if done {
+				break
 			}
-			done := !hasNextPage && i+1 == len(output.ExecutionInfos)
-			cont = fn(info, done) && !done
 		}
 
 		input.OpenNextPageToken = output.OpenNextPageToken
 		input.ClosedNextPageToken = output.ClosedNextPageToken
-		cont = cont && hasNextPage
+		done = done || !hasNextPage // done because paging (didn't iterate)
 	}
 
 	return nil
-
 }
 
 func (c *client) FindLatestByWorkflowID(workflowID string) (exec *swf.WorkflowExecution, err error) {


### PR DESCRIPTION
dogwood-control ftests (luckily!) caught a bug in https://github.com/heroku/dogwood/pull/1706 where the loop never breaks when no items are returned. The actual fix is just one line (db3ef1bc42dc1e42825b4ce132020a1e3aee755a), but I also merged `cont` and `done` since they are really the same concept to improve the logic flow.