### PR TITLE
Fix most selective time filter

### DIFF
--- a/fsm/client_test.go
+++ b/fsm/client_test.go
@@ -283,8 +283,8 @@ func TestFindAll_TimeFiltering(t *testing.T) {
 
 	expectedClosedInput := &swf.ListClosedWorkflowExecutionsInput{
 		Domain:          aws.String(dummyFsm().Domain),
-		StartTimeFilter: input.StartTimeFilter,
-		/* does not include CloseTimeFilter in server request, but filtered later locally */
+		CloseTimeFilter: input.CloseTimeFilter,
+		/* does not include StartTimeFilter in server request, but filtered later locally */
 	}
 	mockSwf.MockOnTyped_ListClosedWorkflowExecutions(expectedClosedInput).Return(
 		func(req *swf.ListClosedWorkflowExecutionsInput) *swf.WorkflowExecutionInfos {
@@ -342,7 +342,7 @@ func TestFindAll_TimeFiltering(t *testing.T) {
 		t.Fatal(output.ExecutionInfos)
 	}
 
-	mockSwf.AssertExpectations(t) // list closed not called
+	mockSwf.AssertExpectations(t) // list open not called
 }
 
 func TestFindAll_CloseStatusFilterDefaultsStatusFilteredToClosed(t *testing.T) {

--- a/fsm/finder.go
+++ b/fsm/finder.go
@@ -193,13 +193,13 @@ func (f *finder) setMostSelectiveMetadataFilter(input *FindInput, output *listAn
 }
 
 func (f *finder) setMostSelectiveTimeFilter(input *FindInput, output *listAnyWorkflowExecutionsInput) {
-	if input.StartTimeFilter != nil {
-		output.StartTimeFilter = input.StartTimeFilter
+	if input.CloseTimeFilter != nil {
+		output.CloseTimeFilter = input.CloseTimeFilter
 		return
 	}
 
-	if input.CloseTimeFilter != nil {
-		output.CloseTimeFilter = input.CloseTimeFilter
+	if input.StartTimeFilter != nil {
+		output.StartTimeFilter = input.StartTimeFilter
 		return
 	}
 }

--- a/fsm/finder.go
+++ b/fsm/finder.go
@@ -102,7 +102,7 @@ func (f *finder) FindAll(input *FindInput) (output *FindOutput, err error) {
 				ReverseOrder:    input.ReverseOrder,
 				MaximumPageSize: input.MaximumPageSize,
 				NextPageToken:   input.OpenNextPageToken,
-				StartTimeFilter: selectiveFilter.StartTimeFilter,
+				StartTimeFilter: input.StartTimeFilter,
 				ExecutionFilter: selectiveFilter.ExecutionFilter,
 				TagFilter:       selectiveFilter.TagFilter,
 				TypeFilter:      selectiveFilter.TypeFilter,
@@ -192,6 +192,7 @@ func (f *finder) setMostSelectiveMetadataFilter(input *FindInput, output *listAn
 	}
 }
 
+// result only used for for closed list. open list uses input.StartTimeFilter directly
 func (f *finder) setMostSelectiveTimeFilter(input *FindInput, output *listAnyWorkflowExecutionsInput) {
 	if input.CloseTimeFilter != nil {
 		output.CloseTimeFilter = input.CloseTimeFilter


### PR DESCRIPTION
Changes `finder.setMostSelectiveTimeFilter` to return the `ClosedTimeFilter` instead of the  `StartTimeFilter` for what to send to SWF for the list closed API call. Note, this is just an optimization without any functional change because `finder.applyInputLocally` still does filtering locally. This is just switching the order to avoid having SWF return a huge list of closed workflows, only to be filtered locally.

See https://github.com/heroku/dogwood/issues/1749#issuecomment-397136918 for why we need this.