### PR TITLE
Add CloseWorkflowRemoveIncompatibleDecisionInterceptor

### DIFF
--- a/fsm/finder.go
+++ b/fsm/finder.go
@@ -295,15 +295,6 @@ func (f *finder) applyInputLocally(input *FindInput, infos []*swf.WorkflowExecut
 	return applied
 }
 
-func stringsContain(haystack []string, needle string) bool {
-	for _, h := range haystack {
-		if h == needle {
-			return true
-		}
-	}
-	return false
-}
-
 type sortExecutionInfos []*swf.WorkflowExecutionInfo
 
 func (e sortExecutionInfos) Len() int      { return len(e) }

--- a/fsm/fsm.go
+++ b/fsm/fsm.go
@@ -891,3 +891,12 @@ func (f *FSM) isErrorMarker(e *swf.HistoryEvent) bool {
 func (f *FSM) EmptyDecisions() []*swf.Decision {
 	return make([]*swf.Decision, 0)
 }
+
+func stringsContain(haystack []string, needle string) bool {
+	for _, h := range haystack {
+		if h == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/fsm/interceptors.go
+++ b/fsm/interceptors.go
@@ -469,9 +469,11 @@ func CloseWorkflowRemoveIncompatibleDecisionInterceptor() DecisionInterceptor {
 			if closingDecisionFound {
 				var decisions []*swf.Decision
 				for _, d := range outcome.Decisions {
-					if !stringsContain(CloseDecisionIncompatableDecisionTypes(), *d.DecisionType) {
-						decisions = append(decisions, d)
+					if stringsContain(CloseDecisionIncompatableDecisionTypes(), *d.DecisionType) {
+						logf(ctx, "fn=CloseWorkflowRemoveIncompatibleDecisionInterceptor at=remove decision-type=%s", *d.DecisionType)
+						continue
 					}
+					decisions = append(decisions, d)
 				}
 				outcome.Decisions = decisions
 			}

--- a/fsm/interceptors.go
+++ b/fsm/interceptors.go
@@ -429,3 +429,52 @@ func (s *StartCancelPair) decisionsContainStartCancel(in []*swf.Decision, cancel
 	}
 	return -1
 }
+
+func CloseDecisionTypes() []string {
+	return []string{
+		swf.DecisionTypeCompleteWorkflowExecution,
+		swf.DecisionTypeCancelWorkflowExecution,
+		swf.DecisionTypeFailWorkflowExecution,
+
+		// swf.DecisionTypeContinueAsNewWorkflowExecution is technically a close type,
+		// but swfsm currently doesn't really treat it as one and there's
+		// a lot of special logic, so excluding it from here for now
+	}
+}
+
+func CloseDecisionIncompatableDecisionTypes() []string {
+	return []string{
+		// TODO: flush out this list with other incompatible types
+		// TODO: see https://console.aws.amazon.com/support/home?#/case/?caseId=5223303261&displayId=5223303261&language=en
+		swf.DecisionTypeScheduleActivityTask,
+		swf.DecisionTypeStartTimer,
+	}
+}
+
+// CloseWorkflowRemoveIncompatibleDecisionInterceptor checks for
+// incompatible decisions with a Complete workflow decision, and if
+// found removes it from the outcome.
+func CloseWorkflowRemoveIncompatibleDecisionInterceptor() DecisionInterceptor {
+	return &FuncInterceptor{
+		AfterDecisionFn: func(decision *swf.PollForDecisionTaskOutput, ctx *FSMContext, outcome *Outcome) {
+			closingDecisionFound := false
+			// Search for close decisions
+			for _, d := range outcome.Decisions {
+				if stringsContain(CloseDecisionTypes(), *d.DecisionType) {
+					closingDecisionFound = true
+				}
+			}
+
+			// If we have a complete decision, search for banned decisions and drop them.
+			if closingDecisionFound {
+				var decisions []*swf.Decision
+				for _, d := range outcome.Decisions {
+					if !stringsContain(CloseDecisionIncompatableDecisionTypes(), *d.DecisionType) {
+						decisions = append(decisions, d)
+					}
+				}
+				outcome.Decisions = decisions
+			}
+		},
+	}
+}

--- a/fsm/interceptors_test.go
+++ b/fsm/interceptors_test.go
@@ -800,6 +800,31 @@ func TestRemoveLowerPriorityDecisionsExpectsLowerPriorityRemoved(t *testing.T) {
 		outcome.Decisions, "Expected lower priority decisions to have been removed")
 }
 
+func TestCloseWorkflowRemoveIncompatibleDecisionInterceptor(t *testing.T) {
+	// arrange
+	outcome := &Outcome{
+		State:     "state",
+		Data:      "data",
+		Decisions: []*swf.Decision{timerDecision(), scheduleActivityDecision(), completeDecision()},
+	}
+	interceptor := CloseWorkflowRemoveIncompatibleDecisionInterceptor()
+
+	// act
+	interceptor.AfterDecision(nil, interceptorTestContext(), outcome)
+
+	// assert
+	assert.Len(t, outcome.Decisions, 1, "Expected outcome to only have 1 decision because incompatables were removed")
+}
+
+func scheduleActivityDecision() *swf.Decision {
+	return &swf.Decision{
+		DecisionType: S(swf.DecisionTypeScheduleActivityTask),
+		ScheduleActivityTaskDecisionAttributes: &swf.ScheduleActivityTaskDecisionAttributes{
+			ActivityId: S("foobar"),
+		},
+	}
+}
+
 func completeDecision() *swf.Decision {
 	return &swf.Decision{
 		CompleteWorkflowExecutionDecisionAttributes: &swf.CompleteWorkflowExecutionDecisionAttributes{},


### PR DESCRIPTION
To break an import cycle (and put code where it really belongs), move the `CloseWorkflowRemoveIncompatibleDecisionInterceptor` into swfsm. Also exposes `CloseDecisionTypes` and `CloseDecisionIncompatableDecisionTypes` for tests to access.